### PR TITLE
chore: tag unit tests as C sourcecode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cpp blinguist-language=C

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -12,13 +12,13 @@ jobs:
           sudo apt install dos2unix
           sudo apt install python3
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt install clang-format-17
+          sudo apt install clang-format-15
 
       - name: Style Check
         run: |
           chmod +x ./scripts/run-clang-format.sh
           dos2unix ./scripts/run-clang-format.sh
-          CLANG_FORMAT="/usr/bin/clang-format-17" ./scripts/run-clang-format.sh
+          CLANG_FORMAT="/usr/bin/clang-format-15" ./scripts/run-clang-format.sh
           echo "Style check complete"
 
       - name: Check General Rules


### PR DESCRIPTION
## Description

Currently githup flags all unit tests as C++ sourcode since we are using GTest. To display the repository language properly we must flag those files as C sourcode.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?