### PR TITLE
Feat/add libsodum based pbkdf2 algorithm

### DIFF
--- a/lib/include/cardano/buffer.h
+++ b/lib/include/cardano/buffer.h
@@ -209,7 +209,9 @@ CARDANO_EXPORT size_t cardano_buffer_get_capacity(const cardano_buffer_t* buffer
  * \param buffer[in] Target buffer.
  * \param data[in]   Data to append.
  * \param size[in]   Size of the data.
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write(cardano_buffer_t* buffer, const byte_t* data, size_t size);
@@ -222,7 +224,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write(cardano_buffer_t* buffer, co
  * \param buffer[in]        Source buffer.
  * \param data [out]        Output array where data will be copied.
  * \param bytes_to_read[in] Number of bytes to read.
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read(cardano_buffer_t* buffer, byte_t* data, size_t bytes_to_read);
@@ -233,7 +237,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read(cardano_buffer_t* buffer, byt
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   16-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint16_le(cardano_buffer_t* buffer, uint16_t value);
@@ -244,7 +250,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint16_le(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   32-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint32_le(cardano_buffer_t* buffer, uint32_t value);
@@ -255,7 +263,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint32_le(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   64-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint64_le(cardano_buffer_t* buffer, uint64_t value);
@@ -266,7 +276,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint64_le(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   16-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int16_le(cardano_buffer_t* buffer, int16_t value);
@@ -277,7 +289,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int16_le(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   32-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int32_le(cardano_buffer_t* buffer, int32_t value);
@@ -288,7 +302,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int32_le(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   64-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int64_le(cardano_buffer_t* buffer, int64_t value);
@@ -299,7 +315,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int64_le(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   float to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_float_le(cardano_buffer_t* buffer, float value);
@@ -310,7 +328,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_float_le(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   double to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_double_le(cardano_buffer_t* buffer, double value);
@@ -321,7 +341,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_double_le(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   16-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint16_be(cardano_buffer_t* buffer, uint16_t value);
@@ -332,7 +354,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint16_be(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   32-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint32_be(cardano_buffer_t* buffer, uint32_t value);
@@ -343,7 +367,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint32_be(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   64-bit unsigned integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint64_be(cardano_buffer_t* buffer, uint64_t value);
@@ -354,7 +380,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_uint64_be(cardano_buffer_t* 
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   16-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int16_be(cardano_buffer_t* buffer, int16_t value);
@@ -365,7 +393,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int16_be(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   32-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int32_be(cardano_buffer_t* buffer, int32_t value);
@@ -376,7 +406,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int32_be(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   64-bit integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_int64_be(cardano_buffer_t* buffer, int64_t value);
@@ -387,7 +419,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_int64_be(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   float integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_float_be(cardano_buffer_t* buffer, float value);
@@ -398,7 +432,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_float_be(cardano_buffer_t* b
  * \param buffer[in]  Target buffer for writing.
  * \param value[in]   double integer to be written.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_write_double_be(cardano_buffer_t* buffer, double value);
@@ -409,7 +445,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_write_double_be(cardano_buffer_t* 
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 16-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint16_le(cardano_buffer_t* buffer, uint16_t* value);
@@ -420,7 +458,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint16_le(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 32-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint32_le(cardano_buffer_t* buffer, uint32_t* value);
@@ -431,7 +471,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint32_le(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 64-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint64_le(cardano_buffer_t* buffer, uint64_t* value);
@@ -442,7 +484,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint64_le(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 16-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int16_le(cardano_buffer_t* buffer, int16_t* value);
@@ -453,7 +497,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int16_le(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 32-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int32_le(cardano_buffer_t* buffer, int32_t* value);
@@ -464,7 +510,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int32_le(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 64-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int64_le(cardano_buffer_t* buffer, int64_t* value);
@@ -475,7 +523,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int64_le(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a float where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_float_le(cardano_buffer_t* buffer, float* value);
@@ -486,7 +536,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_float_le(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a double where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_double_le(cardano_buffer_t* buffer, double* value);
@@ -497,7 +549,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_double_le(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 16-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint16_be(cardano_buffer_t* buffer, uint16_t* value);
@@ -508,7 +562,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint16_be(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 32-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint32_be(cardano_buffer_t* buffer, uint32_t* value);
@@ -519,7 +575,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint32_be(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 64-bit unsigned integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint64_be(cardano_buffer_t* buffer, uint64_t* value);
@@ -530,7 +588,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_uint64_be(cardano_buffer_t* b
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 16-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int16_be(cardano_buffer_t* buffer, int16_t* value);
@@ -541,7 +601,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int16_be(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 32-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int32_be(cardano_buffer_t* buffer, int32_t* value);
@@ -552,7 +614,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int32_be(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a 64-bit integer where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_int64_be(cardano_buffer_t* buffer, int64_t* value);
@@ -563,7 +627,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_int64_be(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a float where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_float_be(cardano_buffer_t* buffer, float* value);
@@ -574,7 +640,9 @@ CARDANO_EXPORT cardano_error_t cardano_buffer_read_float_be(cardano_buffer_t* bu
  * \param buffer[in]   Source buffer for reading.
  * \param value[out]   Pointer to a double where the result will be stored.
  *
- * \return <tt>cardano_error_t</tt> <tt>CARDANO_SUCCESS</tt> on success; otherwise, an error from <tt>cardano_error_t</tt>.
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_buffer_read_double_be(cardano_buffer_t* buffer, double* value);

--- a/lib/include/cardano/cbor/cbor_writer.h
+++ b/lib/include/cardano/cbor/cbor_writer.h
@@ -74,7 +74,7 @@ CARDANO_EXPORT void cardano_cbor_writer_ref(cardano_cbor_writer_t* cbor_writer);
  * \endrst
  *
  * \param cbor_writer the cbor writer object.
- * \return the reference count
+ * \return the reference count.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_cbor_writer_refcount(const cardano_cbor_writer_t* cbor_writer);
@@ -93,7 +93,7 @@ CARDANO_EXPORT size_t cardano_cbor_writer_refcount(const cardano_cbor_writer_t* 
  * \endrst
  *
  * \param object Reference to an object
- * \return the object with reference count decreased by one
+ * \return the object with reference count decreased by one.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_cbor_writer_t* cardano_cbor_writer_move(cardano_cbor_writer_t* cbor_writer);
@@ -103,6 +103,10 @@ CARDANO_EXPORT cardano_cbor_writer_t* cardano_cbor_writer_move(cardano_cbor_writ
  *
  * \param writer[in] The CBOR writer instance.
  * \param value[in]  The value to write.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_big_integer(cardano_cbor_writer_t* writer, uint64_t value);
@@ -110,101 +114,329 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_big_integer(cardano_cbo
 /**
  * \brief Writes a boolean value (major type 7).
  *
+ * \param writer[in] The CBOR writer instance.
  * \param value The value to write.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_bool(cardano_cbor_writer_t* writer, bool value);
 
 /**
- * \brief Writes a buffer as a byte string encoding (major type 2).
+ * \brief Writes a buffer as a byte string encoding (major type 2) into a CBOR stream.
  *
- * \param value The value to write.
+ * This function takes a byte buffer and writes it to the specified CBOR writer as a byte string,
+ * following the CBOR encoding rules for byte strings (major type 2). This is used to serialize
+ * raw binary data in CBOR format.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the byte string will be written. This writer must have been previously
+ *               initialized and be in a valid state for writing.
+ *
+ * \param data A pointer to the byte buffer containing the data to be written as a CBOR byte string.
+ *             The data in this buffer will be copied exactly as it is into the CBOR stream, encoded
+ *             as a byte string.
+ *
+ * \param size The size of the data buffer in bytes. This specifies how many bytes from \c data
+ *             should be written to the CBOR stream as part of the byte string. The length of the
+ *             resulting CBOR byte string will match this size.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation. Returns \c CARDANO_SUCCESS
+ *         on successful writing of the byte string to the CBOR stream. If the operation fails,
+ *         an appropriate error code is returned indicating the reason for failure. Refer to the
+ *         \c cardano_error_t documentation for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_byte_string(cardano_cbor_writer_t* writer, byte_t* data, size_t size);
 
 /**
- * \brief Writes the next data item as a UTF-8 text string (major type 3).
+ * \brief Writes a given text string as a UTF-8 encoded text string (major type 3) into a CBOR stream.
  *
- * \param value The string.
+ * This function serializes a text string, provided as a UTF-8 encoded `char` array, into the CBOR format
+ * as a text string (major type 3).
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure that represents the target CBOR stream
+ *               where the text string will be written. The writer must have been previously initialized
+ *               and be in a state ready for writing data.
+ *
+ * \param data A pointer to the `char` array containing the UTF-8 encoded text string to be written.
+ *
+ * \param size The number of bytes (characters) to write from the \c data array to the CBOR stream. This size
+ *             should reflect the length of the text string in bytes and does not include a null terminator.
+ *
+ * \return A \c cardano_error_t value indicating the outcome of the write operation. The function returns
+ *         \c CARDANO_SUCCESS if the text string is successfully encoded and written to the CBOR stream.
+ *         If the operation encounters an error, such as an invalid parameter or a problem with the
+ *         CBOR stream, the function returns an error code that identifies the failure reason. For a detailed
+ *         explanation of possible error codes, refer to the documentation on \c cardano_error_t.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_text_string(cardano_cbor_writer_t* writer, const char* data, size_t size);
 
 /**
- * \brief Writes a single CBOR data item which has already been encoded.
+ * \brief Writes a pre-encoded CBOR data item to the CBOR stream.
  *
- * \param value The value to write.
+ * This function is designed to directly write a CBOR-encoded data item into the CBOR writer stream,
+ * bypassing the typical encoding process. It is useful for cases where the data to be written is
+ * already in CBOR format and needs to be inserted into the stream as is.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the pre-encoded data item will be written. The writer must have been
+ *               previously initialized and in a valid state for writing.
+ *
+ * \param data A pointer to the byte buffer containing the pre-encoded CBOR data item. This buffer
+ *             is written directly to the CBOR stream without modification, assuming it is correctly
+ *             encoded per CBOR specifications.
+ *
+ * \param size The size of the pre-encoded data buffer in bytes, indicating how many bytes from
+ *             \c data should be written to the CBOR stream. It is the caller's responsibility to
+ *             ensure that the data conforms to valid CBOR encoding rules for the intended data item.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation. Returns \c CARDANO_SUCCESS
+ *         if the pre-encoded data item was successfully written to the CBOR stream. If the operation
+ *         fails, an appropriate error code is returned to indicate the reason for failure. For
+ *         detailed explanations of possible error codes, refer to the \c cardano_error_t documentation.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_encoded(cardano_cbor_writer_t* writer, byte_t* data, size_t size);
 
 /**
- * \brief Writes the start of a definite or indefinite-length array (major type 4).
+ * \brief Writes the start marker for a CBOR array (major type 4) to the CBOR stream.
  *
- * \param length The length of the definite-length array, or 0 for an indefinite-length array.
+ * This function initiates the definition of a CBOR array in the output stream managed by the given CBOR writer.
+ * It supports both definite-length arrays, where the number of elements in the array is known and specified in advance,
+ * and indefinite-length arrays, where the number of elements is not known at the start of the array encoding.
+ *
+ * For a definite-length array, the `length` parameter should be set to the number of elements that will be included
+ * in the array. For an indefinite-length array, `length` should be set to 0, and the array must be explicitly closed
+ * using `cardano_cbor_writer_write_end_array` after all elements have been written.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the array start marker will be written. This writer must have been previously
+ *               initialized and be in a valid state for writing.
+ *
+ * \param length The number of elements in the array for a definite-length array. Set to 0 to start
+ *               an indefinite-length array. In the case of an indefinite-length array, elements can be
+ *               written until `cardano_cbor_writer_write_end_array` is called to mark the end of the array.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation. \c CARDANO_SUCCESS is returned upon
+ *         successful writing of the array start marker. If the operation fails, an appropriate error code is
+ *         returned indicating the reason for the failure. Refer to the \c cardano_error_t documentation
+ *         for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_start_array(cardano_cbor_writer_t* writer, size_t size);
 
 /**
- * \brief Writes the end of an array (major type 4).
+ * \brief Writes the end marker for an indefinite-length array (major type 4) in CBOR format.
+ *
+ * This function is used to conclude the writing of an indefinite-length array in CBOR encoding.
+ * It should be called only after starting an indefinite-length array with
+ * cardano_cbor_writer_write_start_array() where the length parameter was set to 0. For definite-length
+ * arrays, this function is not needed as the length is predefined. This operation inserts an
+ * appropriate end-of-array marker into the CBOR stream to signify the end of the array structure.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the end-of-array marker will be written. This writer must have been previously
+ *               initialized and must be in a valid state for writing.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation. Returns \c CARDANO_SUCCESS
+ *         on successful insertion of the end-of-array marker into the CBOR stream. If the operation
+ *         fails, an appropriate error code is returned indicating the reason for failure. Refer to
+ *         the \c cardano_error_t documentation for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_end_array(cardano_cbor_writer_t* writer);
 
 /**
- * \brief Writes the start of a definite or indefinite-length map (major type 5).
+ * \brief Initiates the writing of a CBOR map (major type 5), supporting both definite and indefinite lengths.
  *
- * \param length The length of the definite-length map, or 0 for an indefinite-length map.
+ * This function marks the beginning of a map in CBOR encoding. CBOR maps consist of key-value pairs.
+ * The function supports both definite-length maps, where the number of key-value pairs is known in advance,
+ * and indefinite-length maps, for which the total number of pairs is not predetermined. For definite-length
+ * maps, the caller must specify the exact number of pairs to be written. For indefinite-length maps,
+ * the caller should pass 0 as the length, and then use cardano_cbor_writer_write_end_map() to denote
+ * the end of the map.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure, representing the CBOR stream
+ *               to which the map's start will be written. This writer should have been previously
+ *               initialized and be in a valid state for writing.
+ *
+ * \param length Specifies the number of key-value pairs for definite-length maps, or 0 to start
+ *               an indefinite-length map. In the case of indefinite-length maps, the end of the map
+ *               must be explicitly marked using cardano_cbor_writer_write_end_map().
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation: \c CARDANO_SUCCESS on successful
+ *         initiation of the map in the CBOR stream, or an error code indicating the reason for failure
+ *         for unsuccessful attempts. Consult the \c cardano_error_t documentation for detailed explanations
+ *         of possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_start_map(cardano_cbor_writer_t* writer, size_t size);
 
 /**
- * \brief Writes the end of a map (major type 5).
+ * \brief Concludes the writing of an indefinite-length map (major type 5) in CBOR format.
+ *
+ * This function is used to signify the end of an indefinite-length map in a CBOR stream. It is specifically
+ * applicable when a map was started with cardano_cbor_writer_write_start_map() with a length parameter of 0,
+ * indicating an indefinite-length map. Definite-length maps, where the total number of key-value pairs is known
+ * and specified at the start, do not require this function to mark their end, as their boundaries are implicitly
+ * defined by the length parameter.
+ *
+ * It is important to ensure that all key-value pairs intended for the map have been written before calling this
+ * function, as it marks the map's closure in the CBOR encoding. After calling this function, new data items written
+ * to the stream will not be considered part of the map.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the end-of-map marker will be written. The writer must have been previously
+ *               initialized and must be in a valid state for writing.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. Returns \c CARDANO_SUCCESS
+ *         upon successfully marking the end of the map in the CBOR stream. If the operation fails, an
+ *         appropriate error code is returned indicating the reason for failure. Refer to the
+ *         \c cardano_error_t documentation for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_end_map(cardano_cbor_writer_t* writer);
 
 /**
- * \brief Writes a value as a signed integer encoding (major types 0,1)
+ * \brief Writes a value as an unsigned integer encoding (major type 0).
  *
- * \param value The value to write.
+ * This function encodes and writes an unsigned integer to the CBOR stream. In CBOR encoding,
+ * unsigned integers are represented as major type 0. The function handles the encoding according
+ * to the value's size, ensuring optimal CBOR representation. It is suitable for encoding integers
+ * in the range of 0 to 2^64-1.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the integer will be written. The writer must have been previously
+ *               initialized and must be in a valid state for writing.
+ *
+ * \param value The unsigned integer value to be written to the CBOR stream. The function
+ *              supports encoding values in the full unsigned 64-bit integer range.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the reason for failure. Refer to the
+ *         \c cardano_error_t documentation for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_unsigned_int(cardano_cbor_writer_t* writer, uint64_t value);
 
 /**
- * \brief Writes a value as a signed integer encoding (major types 0,1)
+ * \brief Writes a signed integer value using CBOR encoding (major types 0, 1).
  *
- * \param value The value to write.
+ * This function encodes a signed integer value into CBOR format, automatically handling
+ * the selection between major type 0 (positive integers) and major type 1 (negative integers)
+ * based on the sign of the input value. Positive values, including zero, are encoded as
+ * major type 0, while negative values are encoded as major type 1. This allows for
+ * efficient representation of integers within the CBOR stream.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure that represents the CBOR stream
+ *               where the integer value will be written. The writer must have been previously
+ *               initialized and be in a ready state for writing.
+ *
+ * \param value The signed integer value to be written to the CBOR stream. The function will
+ *              correctly handle both positive and negative values, encoding them as per
+ *              CBOR's specification for integer representation.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. Returns \c CARDANO_SUCCESS
+ *         if the integer value is successfully written to the CBOR stream. If the operation fails,
+ *         an error code is returned that indicates the reason for failure. Consult the
+ *         \c cardano_error_t documentation for details on possible error codes.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_signed_int(cardano_cbor_writer_t* writer, int64_t value);
 
 /**
- * \brief Writes a null value (major type 7).
+ * \brief Writes a null value to the CBOR stream (major type 7).
+ *
+ * This function encodes a null value into the CBOR stream being written to, following the CBOR
+ * specification for null values (major type 7, additional information 22).
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               where the null value will be encoded. This writer must have been previously
+ *               initialized and must be in a state ready for writing. The function ensures that
+ *               the null value is correctly inserted into the ongoing stream without altering
+ *               the stream's integrity.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. Returns \c CARDANO_SUCCESS
+ *         upon successfully encoding the null value into the stream. If the operation encounters
+ *         an issue, an error code is returned to indicate the specific failure reason. For a
+ *         comprehensive understanding of possible error codes, refer to the \c cardano_error_t
+ *         documentation.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_null(cardano_cbor_writer_t* writer);
 
 /**
- * \brief Writes an undefined value.
+ * \brief Writes an undefined value to the CBOR stream (major type 7).
+ *
+ * In CBOR encoding, the "undefined" value is used to represent data that is explicitly unspecified.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure representing the CBOR stream
+ *               to which the undefined value will be written. The writer should have been previously
+ *               initialized and must be in a valid state for writing. Using this function correctly
+ *               maintains the integrity of the CBOR stream by ensuring the undefined value is
+ *               properly encoded according to CBOR standards.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. If the undefined value is
+ *         successfully encoded into the CBOR stream, \c CARDANO_SUCCESS is returned. Should there be
+ *         a failure in writing the value, an appropriate error code is returned, providing insight
+ *         into the failure reason. Refer to the \c cardano_error_t documentation for an exhaustive
+ *         list of potential error codes and their meanings.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_undefined(cardano_cbor_writer_t* writer);
 
 /**
- * \brief Assign a semantic tag (major type 6) to the next data item.
+ * \brief Assigns a semantic tag (major type 6) to the next data item in the CBOR stream.
  *
- * \param tag semantic tag.
+ * Semantic tags in CBOR are used to give additional meaning or context to the succeeding data item,
+ * enabling the representation of more complex data structures and types, such as dates, times, and
+ * various domain-specific data types. This function allows for the explicit tagging of the next data
+ * item written to the CBOR stream, following the tag with the data item itself to correctly encode
+ * the intended meaning as per the CBOR standard.
+ *
+ * \param writer A pointer to the \c cardano_cbor_writer_t structure that represents the CBOR stream
+ *               where the tag will be applied. The writer should have been previously initialized
+ *               and must be in a valid state for writing. Proper use of this function ensures that
+ *               the tag is correctly prefixed to the subsequent data item in the CBOR encoding sequence.
+ *
+ * \param tag The semantic tag to be applied. This is a numeric identifier that specifies the type
+ *            or meaning of the next data item according to predefined or application-specific CBOR tags.
+ *            The use of tags is defined within the CBOR specification and can be extended to include
+ *            custom semantic meanings in application-specific contexts.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. If the tag is successfully
+ *         written to the stream, \c CARDANO_SUCCESS is returned. If the operation fails, an error code
+ *         is returned that provides details on the failure reason. For comprehensive information on
+ *         possible error codes and their interpretations, refer to the \c cardano_error_t documentation.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_tag(cardano_cbor_writer_t* writer, cbor_tag_t tag);
 
 /**
- * \brief Returns a new array containing the encoded value.
+ * \brief Encodes the data from the internal context of the writer object into CBOR format and outputs it
+ * to a provided buffer.
+ *
+ * This function encodes data that has been prepared or written to the writer's internal context into the
+ * CBOR format. The encoded data is then written to an output buffer provided by the caller.
+ *
+ * \param writer[in] A pointer to the \c cardano_cbor_writer_t structure representing the context and state
+ *               for the CBOR encoding operation.
+ *
+ * \param data[in] A pointer of a byte array where the encoded data will be written.
+ *
+ * \param size[in] The size of the data byte array.
+ *
+ * \param written[out] A pointer to a size_t variable where the function will store the total number of bytes
+ *                     written into the encoded data buffer.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. \c CARDANO_SUCCESS is returned if the
+ *         data is successfully encoded into CBOR format and stored in the provided buffer. If the operation
+ *         fails, an error code is returned that indicates the specific reason for failure. For detailed
+ *         information on possible error codes and their meanings, consult the \c cardano_error_t documentation.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_encode(cardano_cbor_writer_t* writer, byte_t* data, size_t size, size_t* written);
@@ -223,6 +455,11 @@ CARDANO_EXPORT char* cardano_cbor_writer_encode_hex(cardano_cbor_writer_t* write
 
 /**
  * \brief Resets the writer to have no data.
+ *
+ * \return A \c cardano_error_t indicating the outcome of the operation. \c CARDANO_SUCCESS is returned if the
+ *         data is successfully encoded into CBOR format and stored in the provided buffer. If the operation
+ *         fails, an error code is returned that indicates the specific reason for failure. For detailed
+ *         information on possible error codes and their meanings, consult the \c cardano_error_t documentation.
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_writer_reset(cardano_cbor_writer_t* writer);

--- a/lib/include/cardano/cryptography/pbkdf2.h
+++ b/lib/include/cardano/cryptography/pbkdf2.h
@@ -1,0 +1,73 @@
+/**
+ * \file pbkdf2.h
+ *
+ * \author angel.castillo
+ * \date   Mar 02, 2024
+ *
+ * \section LICENSE
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARDANO_CRYPTOGRAPHY_PBKDF2_H
+#define CARDANO_CRYPTOGRAPHY_PBKDF2_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+#include <cardano/typedefs.h>
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Performs key derivation using the PBKDF2 algorithm with HMAC-SHA512.
+ *
+ * PBKDF2 (Password-Based Key Derivation Function 2) is a key derivation function that has a sliding computational cost,
+ * aimed to reduce vulnerabilities to brute force attacks. It applies a pseudorandom function, such as HMAC-SHA512,
+ * to the input password along with a salt value and repeats the process multiple times to produce a derived key.
+ * The iterations parameter controls the number of times the pseudorandom function is applied, which increases
+ * the computational cost and the time required to compute the derived key, thereby enhancing security.
+ *
+ * \param password[in] The input password from which the key is derived.
+ * \param passwordLength[in] The length of the password.
+ * \param salt[in] A cryptographic salt.
+ * \param saltLength[in] The length of the salt.
+ * \param iterations[in] The number of iterations specifies how many times the pseudorandom function is applied.
+ * \param derivedKey[out] The buffer where the derived key will be stored.
+ * \param derivedKeyLength[in] The desired length of the derived key.
+ *
+ * \return A \c cardano_error_t indicating the result of the operation: \c CARDANO_SUCCESS on success,
+ *         or an appropriate error code indicating the failure reason. Refer to \c cardano_error_t documentation
+ *         for details on possible error codes.
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_cryptography_pbkdf2_hmac_sha512(
+  const byte_t* password,
+  size_t        password_length,
+  const byte_t* salt,
+  size_t        salt_length,
+  uint32_t      iterations,
+  byte_t*       derived_key,
+  size_t        derived_key_length);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // CARDANO_CRYPTOGRAPHY_PBKDF2_H

--- a/lib/src/cryptography/pbkdf2.c
+++ b/lib/src/cryptography/pbkdf2.c
@@ -1,0 +1,115 @@
+/**
+ * \file pbkdf2.c
+ *
+ * \author angel.castillo
+ * \date   Mar 02, 2024
+ *
+ * \section LICENSE
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/cryptography/pbkdf2.h>
+
+#include <assert.h>
+#include <sodium.h>
+#include <string.h>
+
+#include "../config.h"
+#include "../endian.h"
+
+/* DEFINITIONS ****************************************************************/
+
+cardano_error_t
+cardano_cryptography_pbkdf2_hmac_sha512(
+  const byte_t*  password,
+  const size_t   password_length,
+  const byte_t*  salt,
+  const size_t   salt_length,
+  const uint32_t iterations,
+  byte_t*        derived_key,
+  const size_t   derived_key_length)
+{
+  if ((password == NULL) || (salt == NULL) || (derived_key == NULL))
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if ((password_length == 0U) || (salt_length == 0U) || (derived_key_length == 0U))
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  crypto_auth_hmacsha512_state initial_hmac_state   = { 0 };
+  crypto_auth_hmacsha512_state loop_hHmac_state     = { 0 };
+  byte_t                       iteration_vector[4U] = { 0 };
+  byte_t                       temp_digest[64U]     = { 0 };
+  byte_t                       block_digest[64U]    = { 0 };
+
+  crypto_auth_hmacsha512_init(&initial_hmac_state, password, password_length);
+  crypto_auth_hmacsha512_update(&initial_hmac_state, salt, salt_length);
+
+  for (size_t i = 0; (i * crypto_auth_hmacsha512_BYTES) < derived_key_length; ++i)
+  {
+    size_t current_block_length = 0;
+
+    cardano_error_t result = cardano_write_uint32_be((uint32_t)(i + 1U), iteration_vector, sizeof(iteration_vector), 0);
+    assert(result == CARDANO_SUCCESS);
+
+    void* initial_state_copy_result = memcpy(&loop_hHmac_state, &initial_hmac_state, sizeof(crypto_auth_hmacsha512_state));
+    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
+    (void)initial_state_copy_result;
+
+    crypto_auth_hmacsha512_update(&loop_hHmac_state, iteration_vector, sizeof(iteration_vector));
+    crypto_auth_hmacsha512_final(&loop_hHmac_state, temp_digest);
+
+    void* tmp_copy_result = memcpy(block_digest, temp_digest, crypto_auth_hmacsha512_BYTES);
+    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
+    (void)tmp_copy_result;
+
+    for (size_t j = 2; j <= iterations; ++j)
+    {
+      crypto_auth_hmacsha512_init(&loop_hHmac_state, password, password_length);
+      crypto_auth_hmacsha512_update(&loop_hHmac_state, temp_digest, crypto_auth_hmacsha512_BYTES);
+      crypto_auth_hmacsha512_final(&loop_hHmac_state, temp_digest);
+
+      for (size_t k = 0; k < crypto_auth_hmacsha512_BYTES; ++k)
+      {
+        block_digest[k] ^= temp_digest[k];
+      }
+    }
+
+    current_block_length = derived_key_length - (i * crypto_auth_hmacsha512_BYTES);
+
+    if (current_block_length > crypto_auth_hmacsha512_BYTES)
+    {
+      current_block_length = crypto_auth_hmacsha512_BYTES;
+    }
+
+    void* block_digest_copy_result = memcpy(&derived_key[i * crypto_auth_hmacsha512_BYTES], block_digest, current_block_length);
+    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
+    (void)block_digest_copy_result;
+  }
+
+  sodium_memzero((void*)&initial_hmac_state, sizeof(initial_hmac_state));
+  sodium_memzero((void*)&loop_hHmac_state, sizeof(loop_hHmac_state));
+  sodium_memzero((void*)iteration_vector, sizeof(iteration_vector));
+  sodium_memzero((void*)temp_digest, sizeof(temp_digest));
+  sodium_memzero((void*)block_digest, sizeof(block_digest));
+
+  return CARDANO_SUCCESS;
+}

--- a/lib/tests/cryptography/pbkdf2.cpp
+++ b/lib/tests/cryptography/pbkdf2.cpp
@@ -1,0 +1,201 @@
+/**
+ * \file pbkdf2.cpp
+ *
+ * \author angel.castillo
+ * \date   Sep 09, 2023
+ *
+ * \section LICENSE
+ *
+ * Copyright 2023 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+
+#include <cardano/cryptography/pbkdf2.h>
+
+#include <gmock/gmock.h>
+
+/* TEST VECTORS **************************************************************/
+
+typedef struct
+{
+    const byte_t* password;
+    size_t        passwordLength;
+    const byte_t* salt;
+    size_t        saltLength;
+    uint32_t      iterations;
+    size_t        dkLen;
+    const char*   expectedSha512;
+} pbkdf2_hmac_sha512_vectors_t;
+
+// Test vectors taken from https://github.com/browserify/pbkdf2/blob/master/test/fixtures.json
+static const pbkdf2_hmac_sha512_vectors_t pbkdf2_hmac_sha512_test_vectors[] = {
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 1, 32, "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 2, 32, "e1d9c16aa681708a45f5c7c4e215ceb66e011a2e9f0040713f18aefdb866d53c" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 1, 64, "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 2, 64, "e1d9c16aa681708a45f5c7c4e215ceb66e011a2e9f0040713f18aefdb866d53cf76cab2868a39b9f7840edce4fef5a82be67335c77a6068e04112754f27ccf4e" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 4096, 32, "d197b1b33db0143e018b12f3d1d1479e6cdebdcc97c5c0f87f6902e072f457b5" },
+  { (const byte_t*)"passwordPASSWORDpassword", strlen("passwordPASSWORDpassword"), (const byte_t*)"saltSALTsaltSALTsaltSALTsaltSALTsalt", strlen("saltSALTsaltSALTsaltSALTsaltSALTsalt"), 4096, 40, "8c0511f4c6e597c6ac6315d8f0362e225f3c501495ba23b868c005174dc4ee71115b59f9e60cd953" },
+  { (const byte_t*)"pass\u00000word", 10, (const byte_t*)"sa\u00000lt", 6, 4096, 16, "336d14366099e8aac2c46c94a8f178d2" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 1, 10, "867f70cf1ade02cff375" },
+  { (const byte_t*)"password", strlen("password"), (const byte_t*)"salt", strlen("salt"), 1, 100, "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce7b532e206c2967d4c7d2ffa460539fc4d4e5eec70125d74c6c7cf86d25284f297907fcea" }
+};
+
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, correctlyComputesHashesForTestVectors)
+{
+  for (size_t i = 0; i < sizeof(pbkdf2_hmac_sha512_test_vectors) / sizeof(pbkdf2_hmac_sha512_test_vectors[0]); ++i)
+  {
+    const pbkdf2_hmac_sha512_vectors_t* vector = &pbkdf2_hmac_sha512_test_vectors[i];
+
+    byte_t derived_key_buffer[vector->dkLen] = { 0 };
+
+    cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+      vector->password,
+      vector->passwordLength,
+      vector->salt,
+      vector->saltLength,
+      vector->iterations,
+      derived_key_buffer,
+      vector->dkLen);
+
+    EXPECT_EQ(result, CARDANO_SUCCESS);
+
+    char derived_key_hex[2 * vector->dkLen + 1];
+
+    for (size_t j = 0; j < vector->dkLen; ++j)
+    {
+      sprintf(&derived_key_hex[2 * j], "%02x", derived_key_buffer[j]);
+    }
+
+    derived_key_hex[2 * vector->dkLen] = '\0';
+
+    EXPECT_STREQ(derived_key_hex, vector->expectedSha512);
+  }
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnNullPassword)
+{
+  // Arrange
+  byte_t derived_key[64U] = { 0 };
+
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    NULL,
+    0U,
+    (const byte_t*)"salt",
+    strlen("salt"),
+    1U,
+    derived_key,
+    sizeof(derived_key));
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnNullSalt)
+{
+  // Arrange
+  byte_t derived_key[64U] = { 0 };
+
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    (const byte_t*)"password",
+    strlen("password"),
+    NULL,
+    0U,
+    1U,
+    derived_key,
+    sizeof(derived_key));
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnNullDerivedKey)
+{
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    (const byte_t*)"password",
+    strlen("password"),
+    (const byte_t*)"salt",
+    strlen("salt"),
+    1U,
+    NULL,
+    0U);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnZeroPasswordLength)
+{
+  // Arrange
+  byte_t derived_key[64U] = { 0 };
+
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    (const byte_t*)"password",
+    0U,
+    (const byte_t*)"salt",
+    strlen("salt"),
+    1U,
+    derived_key,
+    sizeof(derived_key));
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnZeroSaltLength)
+{
+  // Arrange
+  byte_t derived_key[64U] = { 0 };
+
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    (const byte_t*)"password",
+    strlen("password"),
+    (const byte_t*)"salt",
+    0U,
+    1U,
+    derived_key,
+    sizeof(derived_key));
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+}
+
+TEST(cardano_cryptography_pbkdf2_hmac_sha512, returnErrorOnZeroDerivedKeyLength)
+{
+  // Arrange
+  byte_t derived_key[64U] = { 0 };
+
+  // Act
+  cardano_error_t result = cardano_cryptography_pbkdf2_hmac_sha512(
+    (const byte_t*)"password",
+    strlen("password"),
+    (const byte_t*)"salt",
+    strlen("salt"),
+    1U,
+    derived_key,
+    0U);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+}

--- a/lib/tests/error.cpp
+++ b/lib/tests/error.cpp
@@ -99,3 +99,39 @@ TEST(cardano_error_to_string, canConvertUnknown)
   // Assert
   ASSERT_STREQ(message, "Unknown error code");
 }
+
+TEST(cardano_error_to_string, canConvertMemoryAllocationFailed)
+{
+  // Arrange
+  cardano_error_t error = CARDANO_MEMORY_ALLOCATION_FAILED;
+
+  // Act
+  const char* message = cardano_error_to_string(error);
+
+  // Assert
+  ASSERT_STREQ(message, "Invalid operation. Requested memory could not be allocated");
+}
+
+TEST(cardano_error_to_string, canConvertOutOfBoundsMemoryRead)
+{
+  // Arrange
+  cardano_error_t error = CARDANO_OUT_OF_BOUNDS_MEMORY_READ;
+
+  // Act
+  const char* message = cardano_error_to_string(error);
+
+  // Assert
+  ASSERT_STREQ(message, "Invalid operation. Out of bounds memory read");
+}
+
+TEST(cardano_error_to_string, canConvertOutOfBoundsMemoryWrite)
+{
+  // Arrange
+  cardano_error_t error = CARDANO_OUT_OF_BOUNDS_MEMORY_WRITE;
+
+  // Act
+  const char* message = cardano_error_to_string(error);
+
+  // Assert
+  ASSERT_STREQ(message, "Invalid operation. Out of bounds memory write");
+}


### PR DESCRIPTION
## Description

The Password-Based Key Derivation Function 2 (PBKDF2) algorithm is utilized in the Cardano library for key derivation. libsodium doesn't have a out of the box implementation of  PBKDF2, however, it is trivial to implement it in terms of libsodium primitives.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [x] I have added tests
    - [x] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?