### PR TITLE
feat: it is now possible to set what allocators functions the library uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 CMAKE_MINIMUM_REQUIRED (VERSION 2.8)
 PROJECT (cardano-c C)
 
-SET(PROJECT_NAME "libcardano-c")
+SET(PROJECT_NAME "cardano-c")
 
 # Option that the user can optionally select
 OPTION (TESTING_ENABLED "Enables unit test build." ON)

--- a/lib/include/cardano/allocators.h
+++ b/lib/include/cardano/allocators.h
@@ -1,0 +1,116 @@
+/**
+ * \file allocators.h
+ *
+ * \author luisd.bianchi
+ * \date   Mar 11, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARDANO_ALLOCATORS_H
+#define CARDANO_ALLOCATORS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/export.h>
+#include <cardano/typedefs.h>
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Function pointer type for custom memory allocation.
+ *
+ * This typedef defines a custom function signature for memory allocation. Functions matching this
+ * signature can be used to replace the standard malloc function.
+ *
+ * \param size The size in bytes to allocate.
+ * \return A pointer to the allocated memory, or NULL if the allocation fails.
+ */
+typedef void* (*_cardano_malloc_t)(size_t size);
+
+/**
+ * \brief Function pointer type for custom memory reallocation.
+ *
+ * Defines a custom function signature for reallocating memory. Functions with this signature can be used
+ * to replace the standard realloc function.
+ *
+ * \param ptr Pointer to the previously allocated memory block.
+ * \param size The new size in bytes for the memory block.
+ * \return A pointer to the reallocated memory, or NULL if the reallocation fails.
+ */
+typedef void* (*_cardano_realloc_t)(void* ptr, size_t size);
+
+/**
+ * \brief Function pointer type for custom memory deallocation.
+ *
+ * Defines a custom function signature for freeing allocated memory. Functions that match this signature
+ * can replace the standard free function.
+ *
+ * \param ptr Pointer to the memory block to be freed.
+ */
+typedef void (*_cardano_free_t)(void* ptr);
+
+/**
+ * \brief Pointer to a function used for custom memory allocation.
+ *
+ * Points to a user-defined function that allocates memory, following the _cardano_malloc_t signature.
+ * Assign a custom function to this pointer to override the standard memory allocation behavior.
+ */
+extern _cardano_malloc_t _cardano_malloc;
+
+/**
+ * \brief Pointer to a function used for custom memory reallocation.
+ *
+ * Points to a user-defined function for reallocating memory, conforming to the _cardano_realloc_t signature.
+ * Assigning a custom function to this variable allows for overriding the standard memory reallocation mechanism.
+ */
+extern _cardano_realloc_t _cardano_realloc;
+
+/**
+ * \brief Pointer to a function used for custom memory deallocation.
+ *
+ * Points to a user-defined function that frees allocated memory, according to the _cardano_free_t signature.
+ * To customize memory deallocation behavior, assign a custom function to this variable.
+ */
+extern _cardano_free_t _cardano_free;
+
+/**
+ * \brief Sets the memory management routines to use.
+ *
+ * By default, libcardano-c will use the standard library `malloc`, `realloc`, and `free`.
+ *
+ * \warning This function modifies the global state and should therefore be used with caution.
+ * Changing the memory handlers while allocated items exist will result in a `free`/`malloc` mismatch.
+ * This function is not thread-safe with respect to both itself and all other libcardano-c functions
+ * that work with the heap.
+ *
+ * \note The `realloc` implementation must correctly support `NULL` reallocation
+ * (see [realloc documentation](http://en.cppreference.com/w/c/memory/realloc)).
+ *
+ * \param custom_malloc  Function pointer to the custom malloc implementation.
+ * \param custom_realloc Function pointer to the custom realloc implementation.
+ * \param custom_free    Function pointer to the custom free implementation.
+ */
+CARDANO_EXPORT void cardano_set_allocators(_cardano_malloc_t custom_malloc, _cardano_realloc_t custom_realloc, _cardano_free_t custom_free);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // CARDANO_ALLOCATORS_H

--- a/lib/include/cardano/buffer.h
+++ b/lib/include/cardano/buffer.h
@@ -165,7 +165,7 @@ CARDANO_EXPORT cardano_buffer_t* cardano_buffer_from_hex(const char* hex_string,
  * if (hexString != NULL)
  * {
  *     printf("Hex representation: %s\n", hexString);
- *     free(hexString);
+ *     _cardano_free(hexString);
  * }
  *
  * cardano_buffer_unref(&buffer);

--- a/lib/include/cardano/cbor/cbor_writer.h
+++ b/lib/include/cardano/cbor/cbor_writer.h
@@ -785,7 +785,7 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_encode(cardano_cbor_writer_t*
  * if (hex_string != NULL)
  * {
  *     printf("Encoded CBOR data as hex: %s\n", hex_string);
- *     free(hex_string); // Free the allocated string after use
+ *     _cardano_free(hex_string); // Free the allocated string after use
  * }
  * else
  * {

--- a/lib/include/cardano/export.h
+++ b/lib/include/cardano/export.h
@@ -37,15 +37,14 @@ extern "C" {
 #endif
 
 #ifdef __GNUC__
-#define CARDANO_UNUSED(x) __attribute__((__unused__)) (x)
 #define CARDANO_NODISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
-#define CARDANO_UNUSED(x) __pragma(warning(suppress : 4100 4101))(x)
 #define CARDANO_NODISCARD
 #else
-#define CARDANO_UNUSED(x) (x)
 #define CARDANO_NODISCARD
 #endif
+
+#define CARDANO_UNUSED(x) (void)(x)
 
 #ifdef __cplusplus
 }

--- a/lib/src/allocators.c
+++ b/lib/src/allocators.c
@@ -1,12 +1,10 @@
 /**
- * \file Cardano.h
+ * \file allocators.c
  *
- * \author angel.castillo
- * \date   Sep 09, 2023
+ * \author luisd.bianchi
+ * \date   Mar 11, 2024
  *
- * \section LICENSE
- *
- * Copyright 2023 Biglup Labs
+ * Copyright 2024 Biglup Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +19,22 @@
  * limitations under the License.
  */
 
-#ifndef CARDANO_H
-#define CARDANO_H
-
 /* INCLUDES ******************************************************************/
 
 #include <cardano/allocators.h>
-#include <cardano/buffer.h>
-#include <cardano/cbor/cbor_major_type.h>
-#include <cardano/cbor/cbor_reader_state.h>
-#include <cardano/cbor/cbor_simple_value.h>
-#include <cardano/cbor/cbor_tag.h>
-#include <cardano/cbor/cbor_writer.h>
-#include <cardano/error.h>
-#include <cardano/object.h>
-#include <cardano/typedefs.h>
 
-#endif // CARDANO_H
+#include <stdlib.h>
+
+/* DEFINITIONS ***************************************************************/
+
+_cardano_malloc_t  _cardano_malloc  = malloc;
+_cardano_realloc_t _cardano_realloc = realloc;
+_cardano_free_t    _cardano_free    = free;
+
+void
+cardano_set_allocators(_cardano_malloc_t custom_malloc, _cardano_realloc_t custom_realloc, _cardano_free_t custom_free)
+{
+  _cardano_malloc  = custom_malloc;
+  _cardano_realloc = custom_realloc;
+  _cardano_free    = custom_free;
+}

--- a/lib/src/cbor/cbor_writer.c
+++ b/lib/src/cbor/cbor_writer.c
@@ -22,6 +22,8 @@
 /* INCLUDES ******************************************************************/
 
 #include "cbor_additional_info.h"
+
+#include <cardano/allocators.h>
 #include <cardano/buffer.h>
 #include <cardano/cbor/cbor_major_type.h>
 #include <cardano/cbor/cbor_writer.h>
@@ -145,7 +147,7 @@ cardano_cbor_writer_deallocate(void* object)
     cardano_buffer_unref(&cbor_writer->buffer);
   }
 
-  free(cbor_writer);
+  _cardano_free(cbor_writer);
 }
 
 /* DECLARATIONS **************************************************************/
@@ -153,7 +155,7 @@ cardano_cbor_writer_deallocate(void* object)
 cardano_cbor_writer_t*
 cardano_cbor_writer_new(void)
 {
-  cardano_cbor_writer_t* obj = (cardano_cbor_writer_t*)malloc(sizeof(cardano_cbor_writer_t));
+  cardano_cbor_writer_t* obj = (cardano_cbor_writer_t*)_cardano_malloc(sizeof(cardano_cbor_writer_t));
 
   if (obj == NULL)
   {
@@ -167,7 +169,7 @@ cardano_cbor_writer_new(void)
 
   if (obj->buffer == NULL)
   {
-    free(obj);
+    _cardano_free(obj);
     return NULL;
   }
 
@@ -223,7 +225,8 @@ cardano_cbor_writer_move(cardano_cbor_writer_t* cbor_writer)
   }
 
   cardano_object_t* object = cardano_object_move(&cbor_writer->base);
-  (void)object;
+
+  CARDANO_UNUSED(object);
 
   return cbor_writer;
 }
@@ -460,7 +463,7 @@ cardano_cbor_writer_encode(cardano_cbor_writer_t* writer, byte_t* data, size_t s
     return CARDANO_INSUFFICIENT_BUFFER_SIZE;
   }
 
-  (void)memcpy(data, cardano_buffer_get_data(writer->buffer), buffer_size);
+  CARDANO_UNUSED(memcpy(data, cardano_buffer_get_data(writer->buffer), buffer_size));
 
   *written = buffer_size;
 

--- a/lib/src/collections/array.c
+++ b/lib/src/collections/array.c
@@ -23,6 +23,7 @@
 
 #include "array.h"
 
+#include <cardano/allocators.h>
 #include <cardano/object.h>
 
 #include <assert.h>
@@ -66,7 +67,7 @@ grow_array_if_needed(cardano_array_t* array)
   if ((array->size + 1U) >= array->capacity)
   {
     size_t             new_capacity = (size_t)ceil((float)array->capacity * (float)LIB_CARDANO_C_COLLECTION_GROW_FACTOR);
-    cardano_object_t** new_items    = (cardano_object_t**)realloc(array->items, new_capacity * sizeof(cardano_object_t*));
+    cardano_object_t** new_items    = (cardano_object_t**)_cardano_realloc(array->items, new_capacity * sizeof(cardano_object_t*));
 
     if (new_items == NULL)
     {
@@ -107,11 +108,11 @@ cardano_array_deallocate(void* object)
 
   if (array->items != NULL)
   {
-    free(array->items);
+    _cardano_free(array->items);
     array->items = NULL;
   }
 
-  free(array);
+  _cardano_free(array);
 }
 
 /**
@@ -158,18 +159,18 @@ insertion_sort(cardano_object_t** array, const size_t size, const cardano_array_
 cardano_array_t*
 cardano_array_new(const size_t capacity)
 {
-  cardano_array_t* array = (cardano_array_t*)malloc(sizeof(cardano_array_t));
+  cardano_array_t* array = (cardano_array_t*)_cardano_malloc(sizeof(cardano_array_t));
 
   if (array == NULL)
   {
     return NULL;
   }
 
-  array->items = (cardano_object_t**)malloc(capacity * sizeof(cardano_object_t*));
+  array->items = (cardano_object_t**)_cardano_malloc(capacity * sizeof(cardano_object_t*));
 
   if (array->items == NULL)
   {
-    free(array);
+    _cardano_free(array);
     return NULL;
   }
 
@@ -196,18 +197,18 @@ cardano_array_concat(const cardano_array_t* lhs, const cardano_array_t* rhs)
     return NULL;
   }
 
-  cardano_array_t* array = (cardano_array_t*)malloc(sizeof(cardano_array_t));
+  cardano_array_t* array = (cardano_array_t*)_cardano_malloc(sizeof(cardano_array_t));
 
   if (array == NULL)
   {
     return NULL;
   }
 
-  array->items = (cardano_object_t**)malloc((lhs->size + rhs->size) * sizeof(cardano_object_t*));
+  array->items = (cardano_object_t**)_cardano_malloc((lhs->size + rhs->size) * sizeof(cardano_object_t*));
 
   if (array->items == NULL)
   {
-    free(array);
+    _cardano_free(array);
     return NULL;
   }
 
@@ -273,7 +274,7 @@ cardano_array_slice(const cardano_array_t* array, size_t start, size_t end)
     return NULL;
   }
 
-  cardano_object_t** slice_items = (cardano_object_t**)malloc(slice_size * sizeof(cardano_object_t*));
+  cardano_object_t** slice_items = (cardano_object_t**)_cardano_malloc(slice_size * sizeof(cardano_object_t*));
 
   if (slice_items == NULL)
   {
@@ -287,7 +288,7 @@ cardano_array_slice(const cardano_array_t* array, size_t start, size_t end)
     slice_items[i] = item;
   }
 
-  cardano_array_t* sliced_array = (cardano_array_t*)malloc(sizeof(cardano_array_t));
+  cardano_array_t* sliced_array = (cardano_array_t*)_cardano_malloc(sizeof(cardano_array_t));
 
   if (sliced_array == NULL)
   {
@@ -296,7 +297,7 @@ cardano_array_slice(const cardano_array_t* array, size_t start, size_t end)
       cardano_object_unref(&slice_items[i]);
     }
 
-    free(slice_items);
+    _cardano_free(slice_items);
     return NULL;
   }
 
@@ -360,7 +361,8 @@ cardano_array_move(cardano_array_t* array)
   }
 
   cardano_object_t* object = cardano_object_move(&array->base);
-  (void)object;
+
+  CARDANO_UNUSED(object);
 
   return array;
 }
@@ -521,7 +523,7 @@ cardano_array_filter(const cardano_array_t* array, cardano_array_unary_predicate
     if (predicate(item, context))
     {
       size_t new_size = cardano_array_add(filtered_array, item);
-      (void)new_size;
+      CARDANO_UNUSED(new_size);
     }
   }
 

--- a/lib/src/collections/set.c
+++ b/lib/src/collections/set.c
@@ -23,6 +23,8 @@
 
 #include "set.h"
 
+#include <cardano/allocators.h>
+#include <cardano/export.h>
 #include <cardano/object.h>
 
 #include <assert.h>
@@ -81,7 +83,7 @@ cardano_set_deallocate(void* object)
 
       cardano_object_unref(&(entry->object));
 
-      free(entry);
+      _cardano_free(entry);
 
       entry = next;
     }
@@ -89,7 +91,7 @@ cardano_set_deallocate(void* object)
     set->buckets[i] = NULL;
   }
 
-  free(set);
+  _cardano_free(set);
 }
 
 /* DEFINITIONS ****************************************************************/
@@ -97,15 +99,14 @@ cardano_set_deallocate(void* object)
 cardano_set_t*
 cardano_set_new(cardano_set_compare_item_t compare, cardano_set_hash_func_t hash)
 {
-  cardano_set_t* set = (cardano_set_t*)malloc(sizeof(cardano_set_t));
+  cardano_set_t* set = (cardano_set_t*)_cardano_malloc(sizeof(cardano_set_t));
 
   if (set == NULL)
   {
     return NULL;
   }
 
-  void* result = memset(set->buckets, 0, sizeof(set->buckets));
-  (void)result;
+  CARDANO_UNUSED(memset(set->buckets, 0, sizeof(set->buckets)));
 
   set->size               = 0;
   set->compare            = compare;
@@ -201,7 +202,8 @@ cardano_set_move(cardano_set_t* set)
   }
 
   cardano_object_t* object = cardano_object_move(&set->base);
-  (void)object;
+
+  CARDANO_UNUSED(object);
 
   return set;
 }
@@ -228,7 +230,7 @@ cardano_set_add(cardano_set_t* set, cardano_object_t* item)
     entry = &((*entry)->next);
   }
 
-  *entry = (cardano_set_entry_t*)malloc(sizeof(cardano_set_entry_t));
+  *entry = (cardano_set_entry_t*)_cardano_malloc(sizeof(cardano_set_entry_t));
 
   if (*entry == NULL)
   {
@@ -284,7 +286,7 @@ cardano_set_delete(cardano_set_t* set, cardano_object_t* item)
       *entry                        = (*entry)->next;
 
       cardano_object_unref(&(toDelete->object));
-      free(toDelete);
+      _cardano_free(toDelete);
 
       --set->size;
 
@@ -354,7 +356,7 @@ cardano_set_clear(cardano_set_t* set)
     {
       cardano_set_entry_t* next = entry->next;
       cardano_object_unref(&entry->object); // Assuming this is the correct function name.
-      free(entry);
+      _cardano_free(entry);
       entry = next;
     }
 

--- a/lib/src/cryptography/pbkdf2.c
+++ b/lib/src/cryptography/pbkdf2.c
@@ -23,11 +23,12 @@
 
 #include <cardano/cryptography/pbkdf2.h>
 
+#include <cardano/export.h>
+
 #include <assert.h>
 #include <sodium.h>
 #include <string.h>
 
-#include "../config.h"
 #include "../endian.h"
 
 /* DEFINITIONS ****************************************************************/
@@ -65,21 +66,14 @@ cardano_cryptography_pbkdf2_hmac_sha512(
   {
     size_t current_block_length = 0;
 
-    cardano_error_t result = cardano_write_uint32_be((uint32_t)(i + 1U), iteration_vector, sizeof(iteration_vector), 0);
+    CARDANO_UNUSED(cardano_write_uint32_be((uint32_t)(i + 1U), iteration_vector, sizeof(iteration_vector), 0));
 
-    (void)result;
-    assert(result == CARDANO_SUCCESS);
-
-    void* initial_state_copy_result = memcpy(&loop_hHmac_state, &initial_hmac_state, sizeof(crypto_auth_hmacsha512_state));
-    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
-    (void)initial_state_copy_result;
+    CARDANO_UNUSED(memcpy(&loop_hHmac_state, &initial_hmac_state, sizeof(crypto_auth_hmacsha512_state)));
 
     crypto_auth_hmacsha512_update(&loop_hHmac_state, iteration_vector, sizeof(iteration_vector));
     crypto_auth_hmacsha512_final(&loop_hHmac_state, temp_digest);
 
-    void* tmp_copy_result = memcpy(block_digest, temp_digest, crypto_auth_hmacsha512_BYTES);
-    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
-    (void)tmp_copy_result;
+    CARDANO_UNUSED(memcpy(block_digest, temp_digest, crypto_auth_hmacsha512_BYTES));
 
     for (size_t j = 2; j <= iterations; ++j)
     {
@@ -100,9 +94,7 @@ cardano_cryptography_pbkdf2_hmac_sha512(
       current_block_length = crypto_auth_hmacsha512_BYTES;
     }
 
-    void* block_digest_copy_result = memcpy(&derived_key[i * crypto_auth_hmacsha512_BYTES], block_digest, current_block_length);
-    // Satisfies misra-c2012-17.7. memcpy doesn't return any useful feedback, so it's safe to ignore.
-    (void)block_digest_copy_result;
+    CARDANO_UNUSED(memcpy(&derived_key[i * crypto_auth_hmacsha512_BYTES], block_digest, current_block_length));
   }
 
   sodium_memzero((void*)&initial_hmac_state, sizeof(initial_hmac_state));

--- a/lib/src/endian.c
+++ b/lib/src/endian.c
@@ -22,6 +22,9 @@
 /* INCLUDES ******************************************************************/
 
 #include "endian.h"
+
+#include <cardano/export.h>
+
 #include <string.h>
 
 /* CONSTANTS *****************************************************************/
@@ -77,7 +80,7 @@ write(
 
   if (is_native_endian)
   {
-    (void)memcpy(&dest[offset], src, src_size);
+    CARDANO_UNUSED(memcpy(&dest[offset], src, src_size));
   }
   else
   {
@@ -115,7 +118,7 @@ read(
 
   if (is_native_endian)
   {
-    (void)memcpy(dest, &src[offset], dest_size);
+    CARDANO_UNUSED(memcpy(dest, &src[offset], dest_size));
   }
   else
   {

--- a/lib/src/object.c
+++ b/lib/src/object.c
@@ -21,10 +21,10 @@
 
 /* INCLUDES ******************************************************************/
 
+#include <cardano/export.h>
 #include <cardano/object.h>
 
 #include <assert.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "./config.h"
@@ -50,7 +50,8 @@ safe_string_copy(char* dest, const char* src, size_t max_dest_size)
 
   void* result = memcpy(dest, src, copy_size);
 
-  (void)result;
+  CARDANO_UNUSED(result);
+
   assert(result != NULL);
 
   dest[copy_size] = '\0';

--- a/lib/tests/allocators.cpp
+++ b/lib/tests/allocators.cpp
@@ -1,8 +1,8 @@
 /**
- * \file Cardano.h
+ * \file allocators.cpp
  *
- * \author angel.castillo
- * \date   Sep 09, 2023
+ * \author luisd.bianchi
+ * \date   Mar 11, 2024
  *
  * \section LICENSE
  *
@@ -21,20 +21,25 @@
  * limitations under the License.
  */
 
-#ifndef CARDANO_H
-#define CARDANO_H
-
 /* INCLUDES ******************************************************************/
 
 #include <cardano/allocators.h>
-#include <cardano/buffer.h>
-#include <cardano/cbor/cbor_major_type.h>
-#include <cardano/cbor/cbor_reader_state.h>
-#include <cardano/cbor/cbor_simple_value.h>
-#include <cardano/cbor/cbor_tag.h>
-#include <cardano/cbor/cbor_writer.h>
-#include <cardano/error.h>
-#include <cardano/object.h>
-#include <cardano/typedefs.h>
+#include <gmock/gmock.h>
 
-#endif // CARDANO_H
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_set_allocators, cbor_set_allocators)
+{
+  // Arrange
+  _cardano_malloc_t  custom_malloc  = (_cardano_malloc_t)NULL;
+  _cardano_realloc_t custom_realloc = (_cardano_realloc_t)NULL;
+  _cardano_free_t    custom_free    = (_cardano_free_t)NULL;
+
+  // Act
+  cardano_set_allocators(custom_malloc, custom_realloc, custom_free);
+
+  // Assert
+  ASSERT_EQ((ptrdiff_t)_cardano_malloc, (ptrdiff_t)NULL);
+  ASSERT_EQ((ptrdiff_t)_cardano_realloc, (ptrdiff_t)NULL);
+  ASSERT_EQ((ptrdiff_t)_cardano_free, (ptrdiff_t)NULL);
+}

--- a/lib/tests/buffer/buffer.cpp
+++ b/lib/tests/buffer/buffer.cpp
@@ -23,6 +23,7 @@
 
 /* INCLUDES ******************************************************************/
 
+#include <cardano/allocators.h>
 #include <cardano/buffer.h>
 
 #include <gmock/gmock.h>
@@ -405,7 +406,7 @@ TEST(cardano_buffer_to_hex, convertBytesToHex)
 
   // Cleanup
   cardano_buffer_unref(&buffer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_buffer_from_hex, whenGivenANullPtrReturnNull)

--- a/lib/tests/cbor_writer/cbor_writer.cpp
+++ b/lib/tests/cbor_writer/cbor_writer.cpp
@@ -23,7 +23,9 @@
 
 /* INCLUDES ******************************************************************/
 
+#include <cardano/allocators.h>
 #include <cardano/cbor/cbor_writer.h>
+
 #include <gmock/gmock.h>
 
 /* STATIC FUNCTIONS **********************************************************/
@@ -41,7 +43,7 @@ test_unsigned_int(cardano_cbor_writer_t* writer, uint64_t value, const char* hex
   EXPECT_EQ(cardano_cbor_writer_write_unsigned_int(writer, value), CARDANO_SUCCESS);
   char* encoded_hex = cardano_cbor_writer_encode_hex(writer);
   ASSERT_EQ(std::string(encoded_hex), hex);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
   EXPECT_EQ(cardano_cbor_writer_reset(writer), CARDANO_SUCCESS);
 }
 
@@ -58,7 +60,7 @@ test_signed_int(cardano_cbor_writer_t* writer, int64_t value, const char* hex)
   EXPECT_EQ(cardano_cbor_writer_write_signed_int(writer, value), CARDANO_SUCCESS);
   char* encoded_hex = cardano_cbor_writer_encode_hex(writer);
   EXPECT_EQ(std::string(encoded_hex), hex);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
   EXPECT_EQ(cardano_cbor_writer_reset(writer), CARDANO_SUCCESS);
 }
 
@@ -75,7 +77,7 @@ test_text_string(cardano_cbor_writer_t* writer, const char* text, const char* he
   EXPECT_EQ(cardano_cbor_writer_write_text_string(writer, text, strlen(text)), CARDANO_SUCCESS);
   char* encoded_hex = cardano_cbor_writer_encode_hex(writer);
   EXPECT_EQ(std::string(encoded_hex), hex);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
   EXPECT_EQ(cardano_cbor_writer_reset(writer), CARDANO_SUCCESS);
 }
 
@@ -266,7 +268,7 @@ TEST(cardano_cbor_writer_write_tag, writesNestedTaggedValues)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_tag, writesSingleTaggedUnixTimeSeconds)
@@ -286,7 +288,7 @@ TEST(cardano_cbor_writer_write_tag, writesSingleTaggedUnixTimeSeconds)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_big_integer, writesTheValueAsATaggedBignumEncoding)
@@ -402,7 +404,7 @@ TEST(cardano_cbor_writer_write_start_array, writeAnIndefiniteSizeArrayWithSevera
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, returnsNullIfGivenANullPtr)
@@ -431,7 +433,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayWithOneUnsignedNumber)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, writeArrayWithSeveralUnsignedNumber)
@@ -455,7 +457,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayWithSeveralUnsignedNumber)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, writeArrayWithMixedTypes)
@@ -480,7 +482,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayWithMixedTypes)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, writeArrayOfStrings)
@@ -503,7 +505,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayOfStrings)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, writeArrayWithSimpleValues)
@@ -527,7 +529,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayWithSimpleValues)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_array, writeArrayWithNestedArrays)
@@ -552,7 +554,7 @@ TEST(cardano_cbor_writer_write_start_array, writeArrayWithNestedArrays)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_byte_string, writeByteString)
@@ -571,7 +573,7 @@ TEST(cardano_cbor_writer_write_byte_string, writeByteString)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_unsigned_int, writeUnsignedIntegers)
@@ -670,7 +672,7 @@ TEST(cardano_cbor_writer_write_start_map, carnWriteFixedLengthMapsWithNestedType
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_start_map, canWriteUndefiniteLenghtMaps)
@@ -700,7 +702,7 @@ TEST(cardano_cbor_writer_write_start_map, canWriteUndefiniteLenghtMaps)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_encoded, writesEncodedValues)
@@ -719,7 +721,7 @@ TEST(cardano_cbor_writer_write_encoded, writesEncodedValues)
 
   // Cleanup
   cardano_cbor_writer_unref(&writer);
-  free(encoded_hex);
+  _cardano_free(encoded_hex);
 }
 
 TEST(cardano_cbor_writer_write_byte_string, returnsErrorIfGivenANullWriter)

--- a/lib/tests/collections/array.cpp
+++ b/lib/tests/collections/array.cpp
@@ -25,6 +25,8 @@
 
 #include "../src/collections/array.h"
 
+#include <cardano/allocators.h>
+
 #include <gmock/gmock.h>
 
 /* STRUCTS *******************************************************************/
@@ -56,11 +58,11 @@ cardano_ref_counted_string_deallocate(void* object)
 
   if (ref_str->string != NULL)
   {
-    free(ref_str->string);
+    _cardano_free(ref_str->string);
     ref_str->string = NULL;
   }
 
-  free(ref_str);
+  _cardano_free(ref_str);
 }
 
 /**
@@ -71,12 +73,12 @@ cardano_ref_counted_string_deallocate(void* object)
 static ref_counted_string_t*
 ref_counted_string_new(const char* string)
 {
-  ref_counted_string_t* ref_counted_string = (ref_counted_string_t*)malloc(sizeof(ref_counted_string_t));
+  ref_counted_string_t* ref_counted_string = (ref_counted_string_t*)_cardano_malloc(sizeof(ref_counted_string_t));
 
   ref_counted_string->base.ref_count     = 1;
   ref_counted_string->base.last_error[0] = '\0';
   ref_counted_string->base.deallocator   = cardano_ref_counted_string_deallocate;
-  ref_counted_string->string             = (char*)malloc(strlen(string) + 1);
+  ref_counted_string->string             = (char*)_cardano_malloc(strlen(string) + 1);
 
   strcpy(ref_counted_string->string, string);
 

--- a/lib/tests/collections/set.cpp
+++ b/lib/tests/collections/set.cpp
@@ -25,6 +25,8 @@
 
 #include "../src/collections/set.h"
 
+#include <cardano/allocators.h>
+
 #include <gmock/gmock.h>
 
 /* STRUCTS *******************************************************************/
@@ -56,11 +58,11 @@ cardano_ref_counted_string_deallocate(void* object)
 
   if (ref_str->string != nullptr)
   {
-    free(ref_str->string);
+    _cardano_free(ref_str->string);
     ref_str->string = nullptr;
   }
 
-  free(ref_str);
+  _cardano_free(ref_str);
 }
 
 /**
@@ -71,12 +73,12 @@ cardano_ref_counted_string_deallocate(void* object)
 static ref_counted_string_t*
 ref_counted_string_new(const char* string)
 {
-  ref_counted_string_t* ref_counted_string = (ref_counted_string_t*)malloc(sizeof(ref_counted_string_t));
+  ref_counted_string_t* ref_counted_string = (ref_counted_string_t*)_cardano_malloc(sizeof(ref_counted_string_t));
 
   ref_counted_string->base.ref_count     = 1;
   ref_counted_string->base.last_error[0] = '\0';
   ref_counted_string->base.deallocator   = cardano_ref_counted_string_deallocate;
-  ref_counted_string->string             = (char*)malloc(strlen(string) + 1);
+  ref_counted_string->string             = (char*)_cardano_malloc(strlen(string) + 1);
 
   strcpy(ref_counted_string->string, string);
 

--- a/lib/tests/object.cpp
+++ b/lib/tests/object.cpp
@@ -23,6 +23,7 @@
 
 /* INCLUDES ******************************************************************/
 
+#include <cardano/allocators.h>
 #include <cardano/object.h>
 
 #include <gmock/gmock.h>
@@ -80,7 +81,7 @@ TEST(cardano_object_new, createsANewObjectWithTheAllocator)
   cardano_object_t* object = nullptr;
 
   // Act
-  object = cardano_object_new(free);
+  object = cardano_object_new(_cardano_free);
 
   // Assert
   EXPECT_THAT(object, testing::Not((cardano_object_t*)nullptr));
@@ -108,7 +109,7 @@ TEST(cardano_object_ref, increasesTheReferenceCount)
   cardano_object_t* object = nullptr;
 
   // Act
-  object = cardano_object_new(free);
+  object = cardano_object_new(_cardano_free);
   cardano_object_ref(object);
 
   // Assert
@@ -150,7 +151,7 @@ TEST(cardano_object_unref, doesntCrashIfGivenANullPtr)
 TEST(cardano_object_unref, decreasesTheReferenceCount)
 {
   // Arrange
-  cardano_object_t* object = cardano_object_new(free);
+  cardano_object_t* object = cardano_object_new(_cardano_free);
 
   // Act
   cardano_object_ref(object);
@@ -170,7 +171,7 @@ TEST(cardano_object_unref, decreasesTheReferenceCount)
 TEST(cardano_object_unref, freesTheObjectIfReferenceReachesZero)
 {
   // Arrange
-  cardano_object_t* object = cardano_object_new(free);
+  cardano_object_t* object = cardano_object_new(_cardano_free);
 
   // Act
   cardano_object_ref(object);
@@ -202,7 +203,7 @@ TEST(cardano_object_move, returnsNullIfObjectIsNull)
 TEST(cardano_object_move, decreasesTheReferenceCountWithoutDeletingTheObject)
 {
   // Arrange
-  cardano_object_t* object = cardano_object_new(free);
+  cardano_object_t* object = cardano_object_new(_cardano_free);
 
   // Act
   EXPECT_THAT(cardano_object_move(object), testing::Not((cardano_object_t*)nullptr));
@@ -231,7 +232,7 @@ TEST(cardano_object_refcount, returnsZeroIfObjectIsNull)
 TEST(cardano_object_get_last_error, returnsNullTerminatedMessage)
 {
   // Arrange
-  cardano_object_t* object  = cardano_object_new(free);
+  cardano_object_t* object  = cardano_object_new(_cardano_free);
   const char*       message = "This is a test message";
 
   // Act
@@ -273,7 +274,7 @@ TEST(cardano_object_set_last_error, doesNothingWhenObjectIsNull)
 TEST(cardano_object_set_last_error, doesNothingWhenWhenMessageIsNull)
 {
   // Arrange
-  cardano_object_t* object  = cardano_object_new(free);
+  cardano_object_t* object  = cardano_object_new(_cardano_free);
   const char*       message = nullptr;
 
   // Act


### PR DESCRIPTION
## Description

We want to allow clients to replace the allocator functions used by this library:

- malloc
- realloc
- free

This is useful for clients with specific memory needs

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?