### PR TITLE
docs: falgs documentation as C rather than C++

### DIFF
--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -18,9 +18,11 @@ extensions = [
     'breathe'
 ]
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 exclude_patterns += ['page_index.rst']
+
+highlight_language = 'c'
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/scripts/create-docs-makefiles.sh
+++ b/scripts/create-docs-makefiles.sh
@@ -60,4 +60,9 @@ CMAKE_OPTIONS="${CMAKE_USER_OPTIONS} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_
 
 echo cmake ${CMAKE_OPTIONS} ${VERSION} ${CMAKELISTS_DIR}
 cmake ${CMAKE_OPTIONS} ${VERSION} ${CMAKELISTS_DIR}
+
 make doc
+
+# doxygen flags C docs as CPP, so we need to change it to C
+find ./build/release/doc/html -type f -exec sed -i 's/C++/C/g' {} \;
+find ./build/release/doc/html -type f -exec sed -i 's/CPP/C/g' {} \;


### PR DESCRIPTION
## Description

The documentation currently tags the source code as C++. This PR makes it so the documentation is generated as C.

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?