### PR TITLE
doc: fix language flag on readthedocs documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,9 @@ build:
       - pip install sphinx sphinx-immaterial breathe
     post_install:
       - ./scripts/create-docs-makefiles.sh
+    post_build:
+      - find ../../../_readthedocs/html -type f -exec sed -i 's/C++/C/g' {} \
+      - find ../../../_readthedocs/html -type f -exec sed -i 's/CPP/C/g' {} \
 
 sphinx:
   configuration: build/release/doc/conf.py

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -20,7 +20,7 @@ The keywords *MUST*, *MUST NOT*, *REQUIRED*, *SHALL*, *SHALL NOT*, *SHOULD*, *SH
 Here are listed most obvious and important general rules. Please check them carefully before you continue with other chapters.
 
 - `clang-format` SHOULD be used with formatting file attached to this repository (version `15.x` is a minimum)
-- Use `C11` standard
+- Use `C99` standard
 - Do not use tabs, use spaces instead
 - Use `4` spaces per indent level
 - Use `1` space between keyword and opening bracket


### PR DESCRIPTION
## Description

Update code flag on readthedocs

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?