### PR TITLE
chore: update ci workflow to run static code analysis on merge

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -3,7 +3,9 @@ name: Static Code Analysis
 on:
   pull_request:
     types: [assigned, opened, reopened, synchronize]
-
+  push:
+    branches:
+      - main
 jobs:
   static_code_analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Static code analysis is not running on merge to main. Add a listener on push event for main branch.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?