### PR TITLE
feat: added base58 and bech32 encoding/decoding functions

### DIFF
--- a/doc/src/sections/api/encoding/base58.rst
+++ b/doc/src/sections/api/encoding/base58.rst
@@ -1,0 +1,16 @@
+Base58
+==========================
+
+.. doxygenfunction:: cardano_encoding_base58_get_encoded_length
+
+------------
+
+.. doxygenfunction:: cardano_encoding_base58_encode
+
+------------
+
+.. doxygenfunction:: cardano_encoding_base58_get_decoded_length
+
+------------
+
+.. doxygenfunction:: cardano_encoding_base58_decode

--- a/doc/src/sections/api/encoding/bech32.rst
+++ b/doc/src/sections/api/encoding/bech32.rst
@@ -1,0 +1,16 @@
+Bech32
+==========================
+
+.. doxygenfunction:: cardano_encoding_bech32_get_encoded_length
+
+------------
+
+.. doxygenfunction:: cardano_encoding_bech32_encode
+
+------------
+
+.. doxygenfunction:: cardano_encoding_bech32_get_decoded_length
+
+------------
+
+.. doxygenfunction:: cardano_encoding_bech32_decode

--- a/doc/src/sections/api/encoding/encoding.rst
+++ b/doc/src/sections/api/encoding/encoding.rst
@@ -1,0 +1,23 @@
+Encoding
+========
+
+This section of the documentation explores two significant encoding schemes used within the Cardano ecosystem: Base58 and Bech32.
+
+**Base58**
+
+Base58 is a binary-to-text encoding scheme primarily used for encoding binary data in a compact, human-friendly format. It was notably used for representing cryptocurrency addresses in Bitcoin and within the Cardano ecosystem during the Byron era. The design of Base58 excludes visually similar characters, helping to prevent reading and typing errors, making it an ideal choice for presenting cryptographic keys and addresses to end-users.
+
+.. note::
+   With the advent of the Shelley era and the introduction of Bech32 encoding for addresses, Base58 usage in the Cardano ecosystem has been deprecated.
+
+**Bech32**
+
+Bech32 is a newer encoding format developed for use with Segregated Witness (SegWit) addresses in Bitcoin, and it has been adopted by other blockchain projects for its efficiency and error detection capabilities. Bech32 addresses consist of a human-readable part (HRP) and a data part encoded using a BCH code for error detection and correction. In the Cardano ecosystem, Bech32 encoding is employed for wallet addresses.
+
+For in-depth information about the functionalities related to Base58 and Bech32 encoding, please refer to the sections below:
+
+.. toctree::
+   :maxdepth: 1
+
+   base58
+   bech32

--- a/doc/src/sections/index.rst
+++ b/doc/src/sections/index.rst
@@ -73,6 +73,7 @@ See `APACHE LICENSE, VERSION 2.0`_
 
     api/cryptography/cryptography
     api/cbor/cbor
+    api/encoding/encoding
     api/buffer
     api/error
     api/object

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -39,5 +39,5 @@ FOREACH(FUZZ_SOURCE ${FUZZ_SOURCES})
 
     # Compiler and linker options for fuzzing and coverage
     TARGET_COMPILE_OPTIONS(${FUZZ_TARGET_NAME} PRIVATE -fsanitize=fuzzer,address -g -O1 -fprofile-instr-generate -fcoverage-mapping -fprofile-arcs -ftest-coverage)
-    TARGET_LINK_LIBRARIES(${FUZZ_TARGET_NAME} PRIVATE  cardano-c sodium gcov -fsanitize=fuzzer,address -fprofile-instr-generate)
+    TARGET_LINK_LIBRARIES(${FUZZ_TARGET_NAME} PRIVATE  cardano-c gcov -fsanitize=fuzzer,address -fprofile-instr-generate)
 ENDFOREACH()

--- a/lib/include/cardano/cardano.h
+++ b/lib/include/cardano/cardano.h
@@ -34,6 +34,16 @@
 #include <cardano/cbor/cbor_simple_value.h>
 #include <cardano/cbor/cbor_tag.h>
 #include <cardano/cbor/cbor_writer.h>
+#include <cardano/crypto/bip32_private_key.h>
+#include <cardano/crypto/bip32_public_key.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/crypto/blake2b_hash_size.h>
+#include <cardano/crypto/ed25519_private_key.h>
+#include <cardano/crypto/ed25519_public_key.h>
+#include <cardano/crypto/ed25519_signature.h>
+#include <cardano/crypto/pbkdf2.h>
+#include <cardano/encoding/base58.h>
+#include <cardano/encoding/bech32.h>
 #include <cardano/error.h>
 #include <cardano/object.h>
 #include <cardano/typedefs.h>

--- a/lib/include/cardano/encoding/base58.h
+++ b/lib/include/cardano/encoding/base58.h
@@ -1,0 +1,226 @@
+/**
+ * \file base58.h
+ *
+ * \author angel.castillo
+ * \date   Apr 01, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARDANO_BASE58_H
+#define CARDANO_BASE58_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+#include <cardano/export.h>
+#include <cardano/typedefs.h>
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Calculates the length of a Base58-encoded string.
+ *
+ * This function computes the length of a string after it has been encoded using Base58. This is
+ * useful for allocating the correct amount of memory for the encoded string.
+ *
+ * \param[in] data Pointer to the input data to be encoded.
+ * \param[in] data_length Length of the input data in bytes.
+ *
+ * \return The length of the encoded Base58 string, including the null terminator.
+ *
+ * To calculate the required buffer size for a Base58-encoded string:
+ * \code{.c}
+ * const byte_t* data = ...; // Your data here
+ * size_t data_length = ...; // Length of your data
+ *
+ * // Calculate the length of the encoded Base58 string
+ * size_t encoded_length = cardano_encoding_base58_get_encoded_length(data, data_length);
+ *
+ * // Allocate memory for the encoded string
+ * char* encoded_string = (char*)malloc(encoded_length);
+ *
+ * if (encoded_string != NULL)
+ * {
+ *   // Proceed with encoding...
+ * }
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT size_t cardano_encoding_base58_get_encoded_length(const byte_t* data, size_t data_length);
+
+/**
+ * \brief Encodes data into a Base58-encoded string.
+ *
+ * This function encodes binary data into a Base58-encoded string. The encoded
+ * string includes a null terminator at the end.
+ *
+ * \param[in] data Pointer to the input data to be encoded.
+ * \param[in] data_length Length of the input data in bytes.
+ * \param[out] output Pointer to the output buffer for the encoded string.
+ * \param[in] output_length Length of the output buffer in bytes.
+ *
+ * \return \c CARDANO_SUCCESS if the encoding was successful, or an appropriate error code otherwise.
+ *
+ * \note The output buffer should be large enough to hold the encoded string and the null terminator.
+ *       Use \c cardano_encoding_base58_get_encoded_length to calculate the exact buffer size required.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Data to encode
+ * const byte_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+ * size_t data_length = sizeof(data);
+ *
+ * // Calculate required buffer size
+ * size_t encoded_length = cardano_encoding_base58_get_encoded_length(data, data_length);
+ *
+ * // Allocate buffer for encoded string
+ * char* encoded_string = (char*)malloc(encoded_length);
+ *
+ * if (encoded_string == NULL)
+ * {
+ *   // Handle memory allocation error
+ * }
+ *
+ * // Encode data to Base58
+ * cardano_error_t result = cardano_encoding_base58_encode(data, data_length, encoded_string, encoded_length);
+ * if (result == CARDANO_SUCCESS)
+ * {
+ *   printf("Base58 Encoded: %s\n", encoded_string);
+ * }
+ * else
+ * {
+ *   // Handle encoding error
+ * }
+ *
+ * // Free allocated buffer
+ * free(encoded_string);
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_encoding_base58_encode(const byte_t* data, size_t data_length, char* output, size_t output_length);
+
+/**
+ * \brief Calculates the length of the data decoded from a Base58 string.
+ *
+ * This function computes the length of the data decoded from a Base58-encoded string. It is useful for allocating
+ * the correct amount of memory for the decoded data. The function accounts for the variable length nature of Base58
+ * encoding and provides the exact length of the decoded binary data
+ *
+ * \param[in] data Pointer to the Base58-encoded string to be decoded.
+ * \param[in] data_length Length of the Base58-encoded string in bytes.
+ *
+ * \return The length of the decoded data in bytes. This length does not include any potential null terminator as the output
+ *         is expected to be binary data. If the input string is invalid or an error occurs during the computation, the function
+ *         returns 0.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Base58-encoded string
+ * const char* encoded_string = "3mJr7AoUCHxNqd";
+ * size_t encoded_length = strlen(encoded_string);
+ *
+ * // Calculate required buffer size for decoded data
+ * size_t decoded_length = cardano_encoding_base58_get_decoded_length(encoded_string, encoded_length);
+ *
+ * // Allocate buffer for decoded data
+ * byte_t* decoded_data = (byte_t*)malloc(decoded_length);
+ *
+ * if (decoded_data == NULL)
+ * {
+ *   // Handle memory allocation error
+ * }
+ *
+ * // Proceed with decoding (assuming a function cardano_encoding_base58_decode exists)
+ * cardano_error_t result = cardano_encoding_base58_decode(encoded_string, encoded_length, decoded_data, decoded_length);
+ *
+ * if (result == CARDANO_SUCCESS)
+ * {
+ *   // Use decoded data
+ * }
+ * else
+ * {
+ *   // Handle decoding error
+ * }
+ *
+ * // Free allocated buffer for decoded data
+ * free(decoded_data);
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT size_t cardano_encoding_base58_get_decoded_length(const char* data, size_t data_length);
+
+/**
+ * \brief Decodes a Base58-encoded string into binary data.
+ *
+ * This function decodes a Base58-encoded string, converting it back into its original binary data form.
+ *
+ * \param[in] input Pointer to the Base58-encoded string that needs to be decoded.
+ * \param[in] input_length Length of the Base58-encoded string, in bytes. This should be the exact length of the input string,
+ *                         excluding any null terminator if present.
+ * \param[out] data Pointer to the buffer where the decoded binary data will be stored. It is the caller's responsibility to ensure
+ *                  that the buffer is sufficiently large to hold the decoded data.
+ * \param[in] data_length The size of the buffer pointed to by `data`, in bytes. This should be computed in advance to be large enough
+ *                        to hold the expected decoded binary data.
+ *
+ * \return \c CARDANO_SUCCESS if the decoding was successful. Otherwise, an appropriate error code is returned indicating the failure reason.
+ *
+ * \note The data buffer should be large enough to hold the decoded binary data. The function `cardano_encoding_base58_get_decoded_length`
+ *       can be used to calculate the required buffer size based on the length of the Base58-encoded string.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Example Base58-encoded string
+ * const char* encoded_string = "3mJr7AoUCHxNqd";
+ * size_t encoded_length = strlen(encoded_string);
+ *
+ * // Calculate required buffer size for decoded data
+ * size_t decoded_length = cardano_encoding_base58_get_decoded_length((const byte_t*)encoded_string, encoded_length);
+ *
+ * // Allocate buffer for decoded data
+ * byte_t* decoded_data = (byte_t*)malloc(decoded_length);
+ * if (!decoded_data)
+ * {
+ *   // Handle memory allocation failure
+ * }
+ *
+ * // Perform the decoding
+ * cardano_error_t result = cardano_encoding_base58_decode(encoded_string, encoded_length, decoded_data, decoded_length);
+ *
+ * if (result == CARDANO_SUCCESS)
+ * {
+ *   // Use the decoded data
+ * }
+ * else
+ * {
+ *   // Handle decoding error
+ * }
+ *
+ * // Clean up
+ * free(decoded_data);
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_encoding_base58_decode(const char* input, size_t input_length, byte_t* data, size_t data_length);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // CARDANO_BASE58_H

--- a/lib/include/cardano/encoding/bech32.h
+++ b/lib/include/cardano/encoding/bech32.h
@@ -1,0 +1,239 @@
+/**
+ * \file bech32.h
+ *
+ * \author angel.castillo
+ * \date   Apr 01, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARDANO_BECH32_H
+#define CARDANO_BECH32_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+#include <cardano/export.h>
+#include <cardano/typedefs.h>
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Calculates the length of a Bech32-encoded string.
+ *
+ * This function computes the length of a string after it has been encoded using Bech32 encoding. The length includes the
+ * human-readable part (HRP), the data part, and the separator.
+ *
+ * \param[in] hrp Pointer to the human-readable part (HRP) of the Bech32-encoded data.
+ * \param[in] hrp_length The length of the HRP in bytes.
+ * \param[in] data Pointer to the binary data that will be encoded in the data part of the Bech32 string.
+ * \param[in] data_length The length of the binary data in bytes.
+ *
+ * \return The length of the Bech32-encoded string including the null terminator. This value can be used to allocate
+ *         an appropriately sized buffer for the encoded string.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Define the human-readable part and the data to be encoded
+ * const char* hrp = "addr";
+ * size_t hrp_length = strlen(hrp);
+ * byte_t data[] = {0x01, 0x02, 0x03, 0x04};
+ * size_t data_length = sizeof(data);
+ *
+ * // Calculate the required buffer size for the Bech32-encoded string
+ * size_t encoded_length = cardano_encoding_bech32_get_encoded_length(hrp, hrp_length, data, data_length);
+ *
+ * // Allocate the buffer for the Bech32-encoded string
+ * char* encoded_string = (char*)malloc(encoded_length);
+ * if (!encoded_string)
+ * {
+ *   // Handle memory allocation failure
+ * }
+ *
+ * // Now you can proceed to encode the data into Bech32 using the allocated buffer
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT size_t cardano_encoding_bech32_get_encoded_length(
+  const char*   hrp,
+  size_t        hrp_length,
+  const byte_t* data,
+  size_t        data_length);
+
+/**
+ * \brief Encodes data into a Bech32-encoded string.
+ *
+ * This function encodes binary data, along with a human-readable part (HRP), into a Bech32-encoded string.
+ *
+ * \param[in] hrp Pointer to the human-readable part (HRP) that conveys contextual information about the encoded data.
+ * \param[in] hrp_length The length of the HRP in bytes.
+ * \param[in] data Pointer to the binary data to be encoded.
+ * \param[in] data_length The length of the binary data in bytes.
+ * \param[out] output Pointer to the buffer where the Bech32-encoded string will be written. The buffer must be
+ *             large enough to hold the encoded string and the null terminator.
+ * \param[in] output_length The size of the output buffer in bytes.
+ *
+ * \return \c CARDANO_SUCCESS if the encoding was successful, or an appropriate error code otherwise.
+ *
+ * \note The function requires that the `output` buffer is pre-allocated and its length (`output_length`) is
+ *       sufficient to hold the entire Bech32-encoded string including the null terminator. To determine the
+ *       necessary buffer size in advance, use the `cardano_encoding_bech32_get_encoded_length` function.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Define the human-readable part (HRP) and the data to be encoded
+ * const char* hrp = "bc";
+ * byte_t data[] = {0x01, 0x02, 0x03, 0x04};
+ * size_t data_length = sizeof(data);
+ *
+ * // Calculate the required buffer size for the Bech32-encoded string
+ * size_t encoded_length = cardano_encoding_bech32_get_encoded_length(hrp, strlen(hrp), data, data_length);
+ *
+ * // Allocate the buffer for the Bech32-encoded string
+ * char* encoded_string = (char*)malloc(encoded_length);
+ * if (!encoded_string)
+ * {
+ *   // Handle memory allocation failure
+ * }
+ *
+ * // Encode the data into Bech32
+ * cardano_error_t result = cardano_encoding_bech32_encode(hrp, strlen(hrp), data, data_length, encoded_string, encoded_length);
+ * if (result == CARDANO_SUCCESS)
+ * {
+ *   printf("Bech32 Encoded: %s\n", encoded_string);
+ * }
+ * else
+ * {
+ *   // Handle encoding failure
+ * }
+ *
+ * // Clean up
+ * free(encoded_string);
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_encoding_bech32_encode(
+  const char*   hrp,
+  size_t        hrp_length,
+  const byte_t* data,
+  size_t        data_length,
+  char*         output,
+  size_t        output_length);
+
+/**
+ * \brief Calculates the length of the data decoded from a Bech32 string.
+ *
+ * This function computes the length of the data that will be obtained after decoding a Bech32-encoded string.
+ * It also provides the length of the human-readable part (HRP) present in the Bech32 string (including the null terminator).
+ *
+ * \param[in] data Pointer to the Bech32-encoded data from which the lengths are to be calculated.
+ * \param[in] data_length The length of the Bech32-encoded data in bytes.
+ * \param[out] hrp_length Pointer to the size_t variable where the length of the HRP will be stored.
+ *             The value is set to the length of the HRP found in the Bech32-encoded string.
+ *
+ * \return The length of the decoded data in bytes. This does not include the length of the HRP.
+ *
+ * \note The function does not decode the data itself; it merely calculates the length of the decoded data
+ *       and the HRP based on the Bech32-encoded string. To decode the actual data, use the
+ *       `cardano_encoding_bech32_decode` function.
+ *
+ * Example usage:
+ * \code{.c}
+ * // Bech32 encoded string
+ * const char* encoded_str = "addr_1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+ * size_t encoded_str_length = strlen(encoded_str);
+ *
+ * // Calculate the lengths of the decoded data and the HRP
+ * size_t hrp_length = 0;
+ * size_t decoded_data_length = cardano_encoding_bech32_get_decoded_length(encoded_str, encoded_str_length, &hrp_length);
+ *
+ * // Now you can allocate memory for the decoded data and the HRP accordingly
+ * byte_t* decoded_data = (byte_t*)malloc(decoded_data_length);
+ * char* hrp = (char*)malloc(hrp_length);
+ *
+ * if (!decoded_data || !hrp)
+ * {
+ *   // Handle memory allocation failure
+ * }
+ *
+ * // Proceed to decode the Bech32 string
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT size_t cardano_encoding_bech32_get_decoded_length(
+  const char* data,
+  size_t      data_length,
+  size_t*     hrp_length);
+
+/**
+ * \brief Decodes a Bech32-encoded string into its original data and human-readable part (HRP).
+ *
+ * This function takes a Bech32-encoded string as input and decodes it back into the original binary data along with
+ * its human-readable part (HRP). The function requires pre-allocated buffers for both the HRP and the decoded data.
+ *
+ * \param[in] input The Bech32-encoded string to be decoded.
+ * \param[in] input_length The length of the Bech32-encoded string.
+ * \param[out] hrp Pre-allocated buffer where the decoded human-readable part (HRP) will be stored.
+ * \param[in] hrp_length The size of the pre-allocated HRP buffer. It must be large enough to store the HRP including the null terminator.
+ * \param[out] data Pre-allocated buffer where the decoded binary data will be stored.
+ * \param[in,out] data_length On input, specifies the size of the pre-allocated data buffer. On output, it is updated to reflect the actual length
+ *                            of the decoded data.
+ *
+ * \return \c CARDANO_SUCCESS if the decoding is successful, otherwise an error code indicating the failure reason.
+ *
+ * \note The function will modify the `data_length` parameter to indicate the actual length of the decoded data. Ensure that the
+ * buffers for `hrp` and `data` are large enough to store the decoded information. Use `cardano_encoding_bech32_get_decoded_length`
+ * to calculate the required buffer sizes.
+ *
+ * Example usage:
+ * \code{.c}
+ * const char* encoded_str = "addr_1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+ * size_t input_length = strlen(encoded_str);
+ * char hrp[10]; // Assume you know the HRP length or have calculated it
+ * byte_t data[32]; // Pre-allocated buffer for decoded data
+ * size_t data_length = sizeof(data);
+ *
+ * cardano_error_t result = cardano_encoding_bech32_decode(encoded_str, input_length, hrp, sizeof(hrp), data, &data_length);
+ *
+ * if (result == CARDANO_SUCCESS)
+ * {
+ *   // Decoded successfully
+ *   printf("HRP: %s\n", hrp);
+ *   // Use the decoded data as needed
+ * }
+ * else
+ * {
+ *   // Handle decoding error
+ * }
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_encoding_bech32_decode(
+  const char* input,
+  size_t      input_length,
+  char*       hrp,
+  size_t      hrp_length,
+  byte_t*     data,
+  size_t      data_length);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // CARDANO_BECH32_H

--- a/lib/src/encoding/base58.c
+++ b/lib/src/encoding/base58.c
@@ -1,0 +1,239 @@
+/**
+ * \file base58.c
+ *
+ * \author angel.castillo
+ * \date   Apr 06, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/allocators.h>
+#include <cardano/encoding/base58.h>
+
+#include <math.h>
+#include <stddef.h>
+#include <string.h>
+
+/* CONSTANTS *****************************************************************/
+
+static const char BASE58_ALPHABET[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Finds the index of a character in the Base58 alphabet.
+ *
+ * \param c The character to find.
+ * \param alphabet The Base58 alphabet.
+ *
+ * \return The index of the character in the alphabet, or -1 if the character is not found.
+ */
+static int64_t
+char_index(const char c, const char* alphabet)
+{
+  for (size_t i = 0; alphabet[i] != '\0'; ++i)
+  {
+    if (alphabet[i] == c)
+    {
+      return (int64_t)i;
+    }
+  }
+
+  return -1;
+}
+
+/* DEFINITIONS ***************************************************************/
+
+size_t
+cardano_encoding_base58_get_encoded_length(const byte_t* data, const size_t data_length)
+{
+  if (data == NULL)
+  {
+    return 0;
+  }
+
+  if (data_length == 0U)
+  {
+    return 1;
+  }
+
+  size_t leading_zeros = 0;
+
+  for (size_t i = 0; (i < data_length) && (data[i] == 0U); ++i)
+  {
+    ++leading_zeros;
+  }
+
+  const double log_ratio       = log(256) / log(58);
+  const size_t non_zero_length = data_length - leading_zeros;
+
+  return (size_t)ceil((double)non_zero_length * log_ratio) + leading_zeros + 1U;
+}
+
+cardano_error_t
+cardano_encoding_base58_encode(
+  const byte_t* data,
+  const size_t  data_length,
+  char*         output,
+  const size_t  output_length)
+{
+  if (data == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (data_length == 0U)
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  if (output == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  size_t encoded_length = cardano_encoding_base58_get_encoded_length(data, data_length);
+
+  if (output_length < encoded_length)
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  uint8_t* temp = (uint8_t*)_cardano_malloc(encoded_length);
+
+  if (!temp)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  CARDANO_UNUSED(memset(temp, 0, encoded_length));
+
+  for (size_t i = 0; i < data_length; i++)
+  {
+    int64_t carry = data[i];
+
+    for (size_t j = encoded_length - 2U; j < encoded_length; j--)
+    {
+      carry   += 256 * (int64_t)temp[j];
+      temp[j] = carry % 58;
+      carry   /= 58;
+    }
+  }
+
+  size_t output_index = 0;
+
+  for (size_t i = 0; (i < encoded_length) && (temp[i] == 0U); i++)
+  {
+    output[output_index] = '1';
+    ++output_index;
+  }
+
+  for (size_t i = 0; i < encoded_length; i++)
+  {
+    if (temp[i] != 0U)
+    {
+      output[output_index] = BASE58_ALPHABET[temp[i]];
+      ++output_index;
+    }
+  }
+
+  output[output_index] = '\0';
+
+  _cardano_free(temp);
+
+  return CARDANO_SUCCESS;
+}
+
+size_t
+cardano_encoding_base58_get_decoded_length(const char* data, const size_t data_length)
+{
+  if (data == NULL)
+  {
+    return 0;
+  }
+
+  if (data_length == 0U)
+  {
+    return 0;
+  }
+
+  double leading_ones = 0.0;
+
+  for (size_t i = 0; (i < data_length) && (data[i] == '1'); ++i)
+  {
+    ++leading_ones;
+  }
+
+  const double log_base256_of_58       = log(58) / log(256);
+  const size_t non_zero_decoded_length = (size_t)floor(((double)data_length - leading_ones) * log_base256_of_58);
+  const size_t decoded_length          = (size_t)leading_ones + non_zero_decoded_length;
+
+  return decoded_length;
+}
+
+cardano_error_t
+cardano_encoding_base58_decode(
+  const char* input,
+  size_t      input_length,
+  byte_t*     data,
+  size_t      data_length)
+{
+  if (data == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (data_length == 0U)
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  if (input == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  size_t decoded_length = cardano_encoding_base58_get_decoded_length(input, input_length);
+
+  if (data_length < decoded_length)
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  CARDANO_UNUSED(memset(data, 0, data_length));
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    int64_t value = char_index(input[i], BASE58_ALPHABET);
+
+    if (value == -1)
+    {
+      return CARDANO_ERROR_DECODING;
+    }
+
+    int64_t carry = value;
+
+    for (int64_t j = (int64_t)decoded_length - 1; j >= 0; --j)
+    {
+      carry   += (int64_t)58 * (int64_t)data[j];
+      data[j] = carry % (int64_t)256U;
+      carry   /= (int64_t)256U;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}

--- a/lib/src/encoding/bech32.c
+++ b/lib/src/encoding/bech32.c
@@ -1,0 +1,879 @@
+/**
+ * \file bech32.c
+ *
+ * \author angel.castillo
+ * \date   Apr 06, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/allocators.h>
+#include <cardano/encoding/bech32.h>
+
+#include <assert.h>
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* CONSTANTS *****************************************************************/
+
+static const size_t BECH32_CHECKSUM_LENGTH = 6;
+static const char   BECH32_SEPARATOR       = '1';
+static const size_t NULL_TERMINATOR_LENGTH = 1;
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Finds the index of a character in a string.
+ *
+ * \param[in] data The data to search.
+ * \param[in] length The length of the data.
+ * \param[in] separator The character to find.
+ *
+ * \return The index of the separator character in the data, or -1 if the separator is not found.
+ */
+static int32_t
+get_index_of(const char* data, const size_t length, const char separator)
+{
+  assert(data != NULL);
+  assert(length > 0U);
+
+  int32_t index = -1;
+
+  for (size_t i = length - 1U; i > 0U; --i)
+  {
+    if (data[i] == separator)
+    {
+      index = (int32_t)i;
+      break;
+    }
+  }
+
+  return index;
+}
+
+/**
+ * \brief Calculate the number of 5-bit groups needed to represent the data.
+ * This is data_length_8bit * 8 (bits) / 5 (bits per group), rounded up to the nearest whole number.
+ *
+ * \param[in] data_length_8bit The length of the data in 8-bit groups.
+ *
+ * \return The length of the data in 5-bit groups.
+ */
+static size_t
+convert_8bit_to_5bit_length(const size_t data_length_8bit)
+{
+  return ((data_length_8bit * 8U) + 4U) / 5U;
+}
+
+/**
+ * \brief Calculate the number of bytes needed to represent the data in 5-bit groups.
+ * This is data_length_5bit * 5 (bits) / 8 (bits per byte), rounded down to the nearest whole number.
+ *
+ * \param[in] data_length_5bit The length of the data in 5-bit groups.
+ *
+ * \return The number of bytes needed to represent the data in 5-bit groups.
+ */
+static size_t
+convert_5bit_to_8bit_length(const size_t data_length_5bit)
+{
+  return (data_length_5bit * 5U) / 8U;
+}
+
+/**
+ * \brief Converts a string to lowercase.
+ *
+ * \param[out] dest Destination string where the lowercase string will be stored.
+ * \param[in] src Source string to be converted to lowercase.
+ * \param[in] length Length of the source string.
+ */
+static void
+to_lower_string(char* dest, const char* src, const size_t length)
+{
+  assert(dest != NULL);
+
+  for (size_t i = 0; i < length; ++i)
+  {
+    dest[i] = (char)tolower((int)src[i]);
+  }
+
+  dest[length] = '\0';
+}
+
+/**
+ * \brief Converts a string to uppercase.
+ *
+ * \param[out] dest Destination string where the uppercase string will be stored.
+ * \param[in] src Source string to be converted to uppercase.
+ * \param[in] length Length of the source string.
+ */
+static void
+to_upper_string(char* dest, const char* src, const size_t length)
+{
+  assert(dest != NULL);
+
+  for (size_t i = 0; i < length; ++i)
+  {
+    dest[i] = (char)toupper((int)src[i]);
+  }
+
+  dest[length] = '\0';
+}
+
+/**
+ * \brief PolyMod takes a byte slice and returns the 32-bit BCH checksum.
+ *
+ * Note that the input bytes to poly_mod need to be squashed to 5-bits tall
+ * before being used in this function.  And this function will not error,
+ * but instead return an unstable checksum, if you give it full-height bytes.
+ *
+ * \param[in] values The values to get the checksum from.
+ * \param[in] length The length of the values array.
+ *
+ * \return The checksum.
+ */
+static uint32_t
+poly_mod(const byte_t* values, const size_t length)
+{
+  assert(values != NULL);
+
+  static const uint32_t GENERATOR[] = { 0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3 };
+
+  uint32_t checksum = 1;
+
+  for (size_t i = 0; i < length; ++i)
+  {
+    byte_t top = (byte_t)(checksum >> 25);
+
+    checksum = ((checksum & 0x1ffffffU) << 5U) ^ values[i];
+
+    for (size_t j = 0; j < 5U; ++j)
+    {
+      if (((top >> j) & 1U) == 1U)
+      {
+        checksum ^= GENERATOR[j];
+      }
+    }
+  }
+
+  return checksum;
+}
+
+/**
+ * \brief Checks if a string contains mixed case letters and formats it to lowercase.
+ *
+ * \param[out] dest Destination string where the lowercase address will be stored.
+ * \param[in] address The address to be verified.
+ * \param[in] length Length of the address string.
+ *
+ * \return 0 if successful, 1 if the address contains mixed case.
+ */
+static cardano_error_t
+check_and_format(char* dest, const char* address, const size_t length)
+{
+  assert(dest != NULL);
+  assert(address != NULL);
+
+  char* low_addr = (char*)_cardano_malloc(length + NULL_TERMINATOR_LENGTH);
+
+  if (low_addr == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  char* high_addr = (char*)_cardano_malloc(length + NULL_TERMINATOR_LENGTH);
+
+  if (high_addr == NULL)
+  {
+    _cardano_free(low_addr);
+
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  to_lower_string(low_addr, address, length);
+  to_upper_string(high_addr, address, length);
+
+  if ((strncmp(address, low_addr, length) != 0) && (strncmp(address, high_addr, length) != 0))
+  {
+    _cardano_free(low_addr);
+    _cardano_free(high_addr);
+
+    return CARDANO_ERROR_DECODING;
+  }
+
+  CARDANO_UNUSED(strncpy(dest, low_addr, length));
+  dest[length] = '\0';
+
+  _cardano_free(low_addr);
+  _cardano_free(high_addr);
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * \brief Expands the human readable part into 5bit-bytes for later processing.
+ *
+ * \param[in] input The human readable part to be expanded.
+ * \param[in] input_length The length of the input string.
+ * \param[out] output A pointer to the pointer of the output array, where the result will be stored.
+ * \param[out] output_length A pointer to a size_t variable, where the length of the output array will be stored.
+ */
+static void
+hrp_expand(const char* input, const size_t input_length, byte_t** output, size_t* output_length)
+{
+  assert(input != NULL);
+  assert(output != NULL);
+  assert(output_length != NULL);
+
+  *output_length = (input_length * 2U) + 1U;
+  *output        = (byte_t*)_cardano_malloc(*output_length * sizeof(byte_t));
+
+  if (*output == NULL)
+  {
+    return;
+  }
+
+  CARDANO_UNUSED(memset(*output, 0, *output_length));
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    const byte_t khar = (byte_t)input[i];
+    (*output)[i]      = khar >> 5;
+  }
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    const byte_t khar                = (byte_t)input[i];
+    (*output)[i + input_length + 1U] = khar & 0x1FU;
+  }
+}
+
+/**
+ * \brief Verifies the checksum of the address.
+ *
+ * \param[in] hrp The human readable part of the address.
+ * \param[in] hrp_length The length of the hrp string.
+ * \param[in] data The data part of the address.
+ * \param[in] data_length The length of the data array.
+ *
+ * \return \c true if the checksum is valid; otherwise; \c false.
+ */
+static bool
+verify_checksum(const char* hrp, const size_t hrp_length, const byte_t* data, const size_t data_length)
+{
+  size_t  expanded_hrp_length = 0;
+  byte_t* expanded_hrp        = NULL;
+
+  assert(hrp != NULL);
+  assert(data != NULL);
+
+  hrp_expand(hrp, hrp_length, &expanded_hrp, &expanded_hrp_length);
+
+  if (expanded_hrp == NULL)
+  {
+    return false;
+  }
+
+  const size_t values_length = expanded_hrp_length + data_length;
+  byte_t*      values        = (byte_t*)_cardano_malloc(values_length * sizeof(byte_t));
+
+  if (values == NULL)
+  {
+    _cardano_free(expanded_hrp);
+    return false;
+  }
+
+  CARDANO_UNUSED(memcpy(values, expanded_hrp, expanded_hrp_length));
+  CARDANO_UNUSED(memcpy(&values[expanded_hrp_length], data, data_length));
+
+  const byte_t checksum = poly_mod(values, values_length);
+
+  _cardano_free(expanded_hrp);
+  _cardano_free(values);
+
+  return checksum == 1U;
+}
+
+/**
+ * Creates an address checksum.
+ *
+ * \param[in] hrp The human readable part of the address.
+ * \param[in] hrp_length The length of the hrp string.
+ * \param[in] data The data part of the address.
+ * \param[in] data_length The length of the data array.
+ * \param[out] checksum Output parameter for the checksum. The caller is responsible for allocating memory for 6 bytes.
+ */
+static cardano_error_t
+create_checksum(const char* hrp, size_t hrp_length, const byte_t* data, const size_t data_length, byte_t* checksum)
+{
+  size_t  expanded_hrp_length = 0;
+  byte_t* expanded_hrp        = NULL;
+
+  assert(hrp != NULL);
+  assert(checksum != NULL);
+
+  hrp_expand(hrp, hrp_length, &expanded_hrp, &expanded_hrp_length);
+
+  if (expanded_hrp == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  const size_t values_length = expanded_hrp_length + data_length + BECH32_CHECKSUM_LENGTH;
+  byte_t*      values        = (byte_t*)_cardano_malloc(values_length * sizeof(byte_t));
+
+  if (values == NULL)
+  {
+    _cardano_free(expanded_hrp);
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  CARDANO_UNUSED(memcpy(values, expanded_hrp, expanded_hrp_length));
+  CARDANO_UNUSED(memcpy(&values[expanded_hrp_length], data, data_length));
+  CARDANO_UNUSED(memset(&values[expanded_hrp_length + data_length], 0, BECH32_CHECKSUM_LENGTH));
+
+  const uint32_t poly_checksum = poly_mod(values, values_length) ^ 1U;
+
+  for (size_t i = 0; i < BECH32_CHECKSUM_LENGTH; i++)
+  {
+    checksum[i] = (poly_checksum >> (5U * (5U - i))) & 0x1fU;
+  }
+
+  _cardano_free(expanded_hrp);
+  _cardano_free(values);
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * Converts a string to an array of squashed bytes.
+ *
+ * \param[in] input The string to be squashed.
+ * \param[in] input_length The length of the input string.
+ * \param[out] output A pointer to the pointer of the output array where the squashed bytes will be stored.
+ * \param[out] output_length A pointer to a size_t variable where the length of the output array will be stored.
+ *
+ * \return 0 if successful, non-zero if the string contains an invalid character.
+ */
+static cardano_error_t
+string_to_squashed_bytes(const char* input, const size_t input_length, byte_t** output, size_t* output_length)
+{
+  assert(input != NULL);
+  assert(output != NULL);
+  assert(output_length != NULL);
+
+  // clang-format off
+
+  static const int16_t
+  ICHARSET[] =
+  {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+    1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+    1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+  };
+
+  // clang-format on
+
+  byte_t* tmp = (byte_t*)_cardano_malloc(input_length * sizeof(byte_t));
+
+  if (tmp == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    unsigned char khar   = input[i];
+    short         buffer = ICHARSET[khar];
+
+    if (buffer == -1)
+    {
+      _cardano_free(tmp);
+      *output = NULL;
+
+      return CARDANO_ERROR_DECODING;
+    }
+
+    tmp[i] = (byte_t)buffer;
+  }
+
+  *output_length = input_length;
+  *output        = tmp;
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * Decodes a bech32 string into a squashed byte array.
+ *
+ * \param[in] address The bech32 address to be decoded.
+ * \param[in] address_length Length of the bech32 address.
+ * \param[out] hrp Output buffer for the human-readable part.
+ * \param[in] hrp_length Length of the buffer allocated for hrp.
+ * \param[out] data Output buffer for the decoded data.
+ * \param[out] data_length Pointer to store the length of the decoded data.
+ *
+ * \return 0 if successful, non-zero if the bech32 string is invalid.
+ */
+static cardano_error_t
+decode_squashed(const char* address, const size_t address_length, char* hrp, const size_t hrp_length, byte_t** data, size_t* data_length)
+{
+  assert(address != NULL);
+  assert(hrp != NULL);
+  assert(data != NULL);
+  assert(*data == NULL);
+  assert(data_length != NULL);
+
+  char* formatted_address = _cardano_malloc(address_length + NULL_TERMINATOR_LENGTH);
+
+  if (formatted_address == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  if (check_and_format(formatted_address, address, address_length) != CARDANO_SUCCESS)
+  {
+    _cardano_free(formatted_address);
+    return CARDANO_ERROR_DECODING;
+  }
+
+  int32_t split_loc = get_index_of(formatted_address, address_length, BECH32_SEPARATOR);
+
+  if (split_loc == -1)
+  {
+    _cardano_free(formatted_address);
+    return CARDANO_ERROR_DECODING;
+  }
+
+  if ((size_t)split_loc >= hrp_length)
+  {
+    _cardano_free(formatted_address);
+    return CARDANO_ERROR_DECODING;
+  }
+
+  CARDANO_UNUSED(memcpy(hrp, formatted_address, split_loc));
+
+  hrp[split_loc]          = '\0';
+  byte_t* squashed        = NULL;
+  size_t  squashed_length = 0;
+
+  if (string_to_squashed_bytes(&formatted_address[split_loc + 1], address_length - (size_t)split_loc - 1U, &squashed, &squashed_length) != CARDANO_SUCCESS)
+  {
+    _cardano_free(formatted_address);
+    return CARDANO_ERROR_DECODING;
+  }
+
+  if (!verify_checksum(hrp, strlen(hrp), squashed, squashed_length))
+  {
+    _cardano_free(formatted_address);
+    _cardano_free(squashed);
+
+    return CARDANO_ERROR_DECODING;
+  }
+
+  *data_length = squashed_length - BECH32_CHECKSUM_LENGTH;
+  *data        = _cardano_malloc(*data_length * sizeof(byte_t));
+
+  if (*data == NULL)
+  {
+    _cardano_free(formatted_address);
+    _cardano_free(squashed);
+
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  CARDANO_UNUSED(memcpy(*data, squashed, *data_length));
+
+  _cardano_free(formatted_address);
+  _cardano_free(squashed);
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * Converts a squashed byte array to a string.
+ *
+ * \param[in] input The squashed byte array to be converted.
+ * \param[in] input_length The length of the squashed byte array.
+ * \param[out] output Pointer to a char* that will point to the newly created string.
+ *
+ * \return 0 on success, non-zero error code on failure.
+ */
+static cardano_error_t
+squashed_bytes_to_string(const byte_t* input, const size_t input_length, char** output)
+{
+  assert(input != NULL);
+  assert(output != NULL);
+  assert(*output == NULL);
+
+  static const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+  *output = _cardano_malloc(input_length + NULL_TERMINATOR_LENGTH);
+
+  if (*output == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    assert((input[i] & 0xE0U) == 0U);
+
+    (*output)[i] = CHARSET[input[i]];
+  }
+
+  (*output)[input_length] = '\0';
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * Encodes a squashed byte array into a bech32 string.
+ *
+ * \param[in] hrp The human-readable part.
+ * \param[in] hrp_length Length of the human-readable part.
+ * \param[in] data The squashed data.
+ * \param[in] data_length Length of the squashed data.
+ * \param[out] output Pointer to the char* that will hold the bech32 encoded string.
+ * \param[in] output_length Length of the output buffer.
+ *
+ * \return 0 on success, non-zero error code on failure. Caller is responsible for freeing the output string.
+ */
+static cardano_error_t
+encode_squashed(
+  const char*   hrp,
+  const size_t  hrp_length,
+  const byte_t* data,
+  const size_t  data_length,
+  char*         output,
+  const size_t  output_length)
+{
+  assert(hrp != NULL);
+  assert(output != NULL);
+
+  byte_t* checksum = (byte_t*)_cardano_malloc(BECH32_CHECKSUM_LENGTH);
+
+  if (checksum == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  cardano_error_t result = create_checksum(hrp, hrp_length, data, data_length, checksum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    _cardano_free(checksum);
+    return result;
+  }
+
+  size_t  combined_length = data_length + BECH32_CHECKSUM_LENGTH;
+  byte_t* combined        = _cardano_malloc(combined_length);
+
+  if (combined == NULL)
+  {
+    _cardano_free(checksum);
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  CARDANO_UNUSED(memcpy(combined, data, data_length));
+  CARDANO_UNUSED(memcpy(&combined[data_length], checksum, BECH32_CHECKSUM_LENGTH));
+
+  char* encoded = NULL;
+  result        = squashed_bytes_to_string(combined, combined_length, &encoded);
+
+  _cardano_free(combined);
+  _cardano_free(checksum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  size_t required_output_length = hrp_length + NULL_TERMINATOR_LENGTH + strlen(encoded);
+
+  if (output_length < required_output_length)
+  {
+    _cardano_free(encoded);
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  int32_t format_result = snprintf(output, output_length, "%s1%s", hrp, encoded);
+
+  _cardano_free(encoded);
+
+  if (format_result < 0)
+  {
+    return CARDANO_ERROR_ENCODING; /* LCOV_EXCL_LINE */
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * Converts full-width (8-bit) bytes into "squashed" 5-bit bytes, and vice versa.
+ *
+ * \param[in] input The data to be squashed.
+ * \param[in] input_length The length of the input data.
+ * \param[in] input_width The width of the input bytes.
+ * \param[in] output_width The width of the output bytes.
+ * \param[out] output A pointer to a buffer that will hold the squashed data. This buffer should be allocated by the caller.
+ * \param[out] output_length The length of the output data (number of bytes).
+ *
+ * \return CARDANO_SUCCESS on success, an error code on failure.
+ */
+static cardano_error_t
+byte_squasher(const byte_t* input, const size_t input_length, const size_t input_width, const size_t output_width, byte_t** output, size_t* output_length)
+{
+  assert(output != NULL);
+  assert(*output == NULL);
+  assert(output_length != NULL);
+
+  if ((input == NULL) || (input_length == 0U))
+  {
+    *output_length = 0;
+    return CARDANO_SUCCESS;
+  }
+
+  size_t         bit_stash        = 0;
+  uint32_t       accumulator      = 0;
+  const uint32_t max_output_value = ((uint32_t)1U << (uint32_t)output_width) - 1U;
+
+  const size_t estimated_output_size = ((input_length * input_width) + (output_width - 1U)) / output_width;
+  *output                            = _cardano_malloc(estimated_output_size);
+
+  if (*output == NULL)
+  {
+    return CARDANO_MEMORY_ALLOCATION_FAILED;
+  }
+
+  size_t current_output_length = 0;
+
+  for (size_t i = 0; i < input_length; ++i)
+  {
+    assert((input[i] >> input_width) == 0U);
+
+    accumulator = (accumulator << input_width) | input[i];
+    bit_stash   += input_width;
+
+    while (bit_stash >= output_width)
+    {
+      bit_stash                        -= output_width;
+      (*output)[current_output_length] = (accumulator >> bit_stash) & max_output_value;
+      ++current_output_length;
+    }
+  }
+
+  if (input_width == 8U)
+  {
+    if (bit_stash != 0U)
+    {
+      (*output)[current_output_length] = (accumulator << (output_width - bit_stash)) & max_output_value;
+      ++current_output_length;
+    }
+  }
+  else
+  {
+    if ((bit_stash >= input_width) || (((accumulator << (output_width - bit_stash)) & max_output_value) != 0U))
+    {
+      _cardano_free(*output);
+      *output = NULL;
+
+      return CARDANO_ERROR_ENCODING;
+    }
+  }
+
+  *output_length = current_output_length;
+
+  return CARDANO_SUCCESS;
+}
+
+/* DEFINITIONS ***************************************************************/
+
+size_t
+cardano_encoding_bech32_get_encoded_length(
+  const char*   hrp,
+  const size_t  hrp_length,
+  const byte_t* data,
+  const size_t  data_length)
+{
+  static const size_t BECH32_SEPARATOR_LENGTH = 1;
+
+  CARDANO_UNUSED(hrp);
+  CARDANO_UNUSED(data);
+
+  return hrp_length +
+    BECH32_SEPARATOR_LENGTH +
+    convert_8bit_to_5bit_length(data_length) +
+    BECH32_CHECKSUM_LENGTH +
+    NULL_TERMINATOR_LENGTH;
+}
+
+cardano_error_t
+cardano_encoding_bech32_encode(
+  const char*   hrp,
+  const size_t  hrp_length,
+  const byte_t* data,
+  const size_t  data_length,
+  char*         output,
+  const size_t  output_length)
+{
+  if (hrp == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if ((data == NULL) && (data_length > 0U))
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (output == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (output_length == 0U)
+  {
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  byte_t* squashed_data   = NULL;
+  size_t  squashed_length = 0;
+
+  cardano_error_t result = byte_squasher(data, data_length, 8, 5, &squashed_data, &squashed_length);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    if (squashed_data != NULL)
+    {
+      _cardano_free(squashed_data); /* LCOV_EXCL_LINE */
+    }
+
+    return result;
+  }
+
+  result = encode_squashed(hrp, hrp_length, squashed_data, squashed_length, output, output_length);
+
+  _cardano_free(squashed_data);
+
+  return result;
+}
+
+size_t
+cardano_encoding_bech32_get_decoded_length(
+  const char*  data,
+  const size_t data_length,
+  size_t*      hrp_length)
+{
+  if (data == NULL)
+  {
+    return 0;
+  }
+
+  if (data_length == 0U)
+  {
+    return 0;
+  }
+
+  if (hrp_length == NULL)
+  {
+    return 0;
+  }
+
+  *hrp_length = 0;
+
+  int32_t separator_index = get_index_of(data, data_length, BECH32_SEPARATOR);
+
+  if (separator_index == -1)
+  {
+    return 0;
+  }
+
+  *hrp_length = separator_index;
+
+  size_t data_part_length = data_length - *hrp_length - NULL_TERMINATOR_LENGTH - BECH32_CHECKSUM_LENGTH;
+
+  size_t decoded_data_length = convert_5bit_to_8bit_length(data_part_length);
+
+  *hrp_length += NULL_TERMINATOR_LENGTH;
+
+  return decoded_data_length;
+}
+
+cardano_error_t
+cardano_encoding_bech32_decode(
+  const char*  input,
+  const size_t input_length,
+  char*        hrp,
+  const size_t hrp_length,
+  byte_t*      data,
+  const size_t data_length)
+{
+  if (input == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (hrp == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  if (data == NULL)
+  {
+    return CARDANO_POINTER_IS_NULL;
+  }
+
+  byte_t* squashed_data   = NULL;
+  size_t  squashed_length = 0;
+
+  cardano_error_t result = decode_squashed(input, input_length, hrp, hrp_length, &squashed_data, &squashed_length);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  byte_t* output_data   = NULL;
+  size_t  output_length = 0;
+
+  result = byte_squasher((byte_t*)squashed_data, squashed_length, 5, 8, &output_data, &output_length);
+
+  _cardano_free(squashed_data);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  if (output_length > data_length)
+  {
+    _cardano_free(output_data);
+    return CARDANO_INSUFFICIENT_BUFFER_SIZE;
+  }
+
+  CARDANO_UNUSED(memcpy(data, output_data, output_length));
+  _cardano_free(output_data);
+
+  return result;
+}

--- a/lib/tests/allocators_helpers.cpp
+++ b/lib/tests/allocators_helpers.cpp
@@ -81,6 +81,39 @@ fail_after_three_malloc(const size_t size)
 }
 
 void*
+fail_after_four_malloc(size_t size)
+{
+  if (malloc_run_count < 4)
+  {
+    malloc_run_count++;
+    return malloc(size);
+  }
+  return NULL;
+}
+
+void*
+fail_after_five_malloc(size_t size)
+{
+  if (malloc_run_count < 5)
+  {
+    malloc_run_count++;
+    return malloc(size);
+  }
+  return NULL;
+}
+
+void*
+fail_after_six_malloc(size_t size)
+{
+  if (malloc_run_count < 6)
+  {
+    malloc_run_count++;
+    return malloc(size);
+  }
+  return NULL;
+}
+
+void*
 fail_right_away_realloc(void* const ptr, const size_t size)
 {
   return NULL;

--- a/lib/tests/allocators_helpers.h
+++ b/lib/tests/allocators_helpers.h
@@ -89,6 +89,45 @@ void*
 fail_after_three_malloc(size_t size);
 
 /**
+ * \brief A mock version of malloc that allows four successful allocation before failing.
+ *
+ * This function simulates a scenario where malloc succeeds on the first, second, third and fourth call but fails
+ * on subsequent calls.
+ *
+ * \param size The size of the memory allocation request.
+ * \return A pointer to allocated memory on the first call, and NULL on subsequent calls
+ *         to simulate allocation failure.
+ */
+void*
+fail_after_four_malloc(size_t size);
+
+/**
+ * \brief A mock version of malloc that allows five successful allocation before failing.
+ *
+ * This function simulates a scenario where malloc succeeds on the first, second, third, fourth and fifth call but fails
+ * on subsequent calls.
+ *
+ * \param size The size of the memory allocation request.
+ * \return A pointer to allocated memory on the first call, and NULL on subsequent calls
+ *         to simulate allocation failure.
+ */
+void*
+fail_after_five_malloc(size_t size);
+
+/**
+ * \brief A mock version of malloc that allows six successful allocation before failing.
+ *
+ * This function simulates a scenario where malloc succeeds on the first, second, third, fourth, fifth and sixth call but fails
+ * on subsequent calls.
+ *
+ * \param size The size of the memory allocation request.
+ * \return A pointer to allocated memory on the first call, and NULL on subsequent calls
+ *         to simulate allocation failure.
+ */
+void*
+fail_after_six_malloc(size_t size);
+
+/**
  * \brief A mock version of realloc that simulates a reallocation failure on the first call.
  *
  * This function is useful for testing how code reacts when realloc fails immediately,

--- a/lib/tests/encoding/base58.cpp
+++ b/lib/tests/encoding/base58.cpp
@@ -1,0 +1,420 @@
+/**
+ * \file base58.cpp
+ *
+ * \author angel.castillo
+ * \date   Apr 06, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/encoding/base58.h>
+#include <gmock/gmock.h>
+
+#include <cardano/allocators.h>
+
+#include "../allocators_helpers.h"
+
+/* STATIC FUNCTIONS **********************************************************/
+
+static bool
+encodes_correctly(const char* encoded, const uint8_t* data, size_t data_size)
+{
+  size_t encoded_size = cardano_encoding_base58_get_encoded_length(data, data_size);
+  char*  result       = (char*)malloc(encoded_size);
+
+  cardano_error_t encode_result = cardano_encoding_base58_encode(data, data_size, result, encoded_size);
+
+  if (encode_result != CARDANO_SUCCESS)
+  {
+    free(result);
+    return false;
+  }
+
+  EXPECT_EQ(strlen(result), strlen(encoded));
+  EXPECT_STREQ(result, encoded);
+
+  bool is_equal = strcmp(result, encoded) == 0;
+
+  free(result);
+
+  return is_equal;
+}
+
+static bool
+decodes_correctly(const char* encoded, const uint8_t* data, size_t data_size)
+{
+  size_t   decoded_size = cardano_encoding_base58_get_decoded_length(encoded, strlen(encoded));
+  uint8_t* result       = (uint8_t*)malloc(decoded_size);
+
+  cardano_error_t decode_result = cardano_encoding_base58_decode(encoded, strlen(encoded), result, decoded_size);
+
+  if (decode_result != CARDANO_SUCCESS)
+  {
+    free(result);
+    return false;
+  }
+
+  EXPECT_EQ(decoded_size, data_size);
+  EXPECT_EQ(memcmp(result, data, data_size), 0);
+
+  const bool is_equal = memcmp(result, data, data_size) == 0;
+
+  free(result);
+
+  return is_equal;
+}
+
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_encoding_base58_encode, canDecodeBase58Strings)
+{
+  // Arrange
+
+  // clang-format off
+  const uint8_t byron_mainnet_yoroi[] = {
+    0x82, 0xd8, 0x18, 0x58, 0x21, 0x83, 0x58, 0x1c, 0xba, 0x97, 0x0a, 0xd3, 0x66, 0x54, 0xd8, 0xdd,
+    0x8f, 0x74, 0x27, 0x4b, 0x73, 0x34, 0x52, 0xdd, 0xea, 0xb9, 0xa6, 0x2a, 0x39, 0x77, 0x46, 0xbe,
+    0x3c, 0x42, 0xcc, 0xdd, 0xa0, 0x00, 0x1a, 0x90, 0x26, 0xda, 0x5b
+  };
+
+  const uint8_t byron_testnet_daedalus[] = {
+    0x82, 0xd8, 0x18, 0x58, 0x49, 0x83, 0x58, 0x1c, 0x9c, 0x70, 0x85, 0x38, 0xa7, 0x63, 0xff, 0x27,
+    0x16, 0x99, 0x87, 0xa4, 0x89, 0xe3, 0x50, 0x57, 0xef, 0x3c, 0xd3, 0x77, 0x8c, 0x05, 0xe9, 0x6f,
+    0x7b, 0xa9, 0x45, 0x0e, 0xa2, 0x01, 0x58, 0x1e, 0x58, 0x1c, 0x9c, 0x17, 0x22, 0xf7, 0xe4, 0x46,
+    0x68, 0x92, 0x56, 0xe1, 0xa3, 0x02, 0x60, 0xf3, 0x51, 0x0d, 0x55, 0x8d, 0x99, 0xd0, 0xc3, 0x91,
+    0xf2, 0xba, 0x89, 0xcb, 0x69, 0x77, 0x02, 0x45, 0x1a, 0x41, 0x70, 0xcb, 0x17, 0x00, 0x1a, 0x69,
+    0x79, 0x12, 0x6c
+  };
+
+  const uint8_t b58_high[] = {
+    0xff, 0x5a, 0x1f, 0xc5, 0xdd, 0x9e, 0x6f, 0x03, 0x81, 0x9f, 0xca, 0x94, 0xa2, 0xd8, 0x96, 0x69,
+    0x46, 0x96, 0x67, 0xf9, 0xa0, 0xc0, 0xd6, 0x8d, 0xec
+  };
+
+  const uint8_t leading_zero[] = {
+    0x00, 0x5a, 0x1f, 0xc5, 0xdd, 0x9e, 0x6f, 0x03, 0x81, 0x9f, 0xca, 0x94, 0xa2, 0xd8, 0x96, 0x69,
+    0x46, 0x96, 0x67, 0xf9, 0xa0, 0x74, 0x65, 0x59, 0x46
+  };
+
+  // clang-format on
+
+  const size_t byron_mainnet_yoroi_size    = sizeof(byron_mainnet_yoroi);
+  const size_t byron_testnet_daedalus_size = sizeof(byron_testnet_daedalus);
+  const size_t b58_high_size               = sizeof(b58_high);
+  const size_t leading_zero_size           = sizeof(leading_zero);
+
+  // Act & Assert
+  EXPECT_EQ(encodes_correctly("Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi", byron_mainnet_yoroi, byron_mainnet_yoroi_size), true);
+  EXPECT_EQ(encodes_correctly("37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT", byron_testnet_daedalus, byron_testnet_daedalus_size), true);
+  EXPECT_EQ(encodes_correctly("2mkQLxaN3Y4CwN5E9rdMWNgsXX7VS6UnfeT", b58_high, b58_high_size), true);
+  EXPECT_EQ(encodes_correctly("19DXstMaV43WpYg4ceREiiTv2UntmoiA9j", leading_zero, leading_zero_size), true);
+}
+
+TEST(cardano_encoding_base58_decode, canEncodeDataInBase58Strings)
+{
+  // Arrange
+
+  // clang-format off
+  const uint8_t byron_mainnet_yoroi[] = {
+    0x82, 0xd8, 0x18, 0x58, 0x21, 0x83, 0x58, 0x1c, 0xba, 0x97, 0x0a, 0xd3, 0x66, 0x54, 0xd8, 0xdd,
+    0x8f, 0x74, 0x27, 0x4b, 0x73, 0x34, 0x52, 0xdd, 0xea, 0xb9, 0xa6, 0x2a, 0x39, 0x77, 0x46, 0xbe,
+    0x3c, 0x42, 0xcc, 0xdd, 0xa0, 0x00, 0x1a, 0x90, 0x26, 0xda, 0x5b
+  };
+
+  const uint8_t byron_testnet_daedalus[] = {
+    0x82, 0xd8, 0x18, 0x58, 0x49, 0x83, 0x58, 0x1c, 0x9c, 0x70, 0x85, 0x38, 0xa7, 0x63, 0xff, 0x27,
+    0x16, 0x99, 0x87, 0xa4, 0x89, 0xe3, 0x50, 0x57, 0xef, 0x3c, 0xd3, 0x77, 0x8c, 0x05, 0xe9, 0x6f,
+    0x7b, 0xa9, 0x45, 0x0e, 0xa2, 0x01, 0x58, 0x1e, 0x58, 0x1c, 0x9c, 0x17, 0x22, 0xf7, 0xe4, 0x46,
+    0x68, 0x92, 0x56, 0xe1, 0xa3, 0x02, 0x60, 0xf3, 0x51, 0x0d, 0x55, 0x8d, 0x99, 0xd0, 0xc3, 0x91,
+    0xf2, 0xba, 0x89, 0xcb, 0x69, 0x77, 0x02, 0x45, 0x1a, 0x41, 0x70, 0xcb, 0x17, 0x00, 0x1a, 0x69,
+    0x79, 0x12, 0x6c
+  };
+
+  const uint8_t b58_high[] = {
+    0xff, 0x5a, 0x1f, 0xc5, 0xdd, 0x9e, 0x6f, 0x03, 0x81, 0x9f, 0xca, 0x94, 0xa2, 0xd8, 0x96, 0x69,
+    0x46, 0x96, 0x67, 0xf9, 0xa0, 0xc0, 0xd6, 0x8d, 0xec
+  };
+
+  const uint8_t leading_zero[] = {
+    0x00, 0x5a, 0x1f, 0xc5, 0xdd, 0x9e, 0x6f, 0x03, 0x81, 0x9f, 0xca, 0x94, 0xa2, 0xd8, 0x96, 0x69,
+    0x46, 0x96, 0x67, 0xf9, 0xa0, 0x74, 0x65, 0x59, 0x46
+  };
+
+  // clang-format on
+
+  const size_t byron_mainnet_yoroi_size    = sizeof(byron_mainnet_yoroi);
+  const size_t byron_testnet_daedalus_size = sizeof(byron_testnet_daedalus);
+  const size_t b58_high_size               = sizeof(b58_high);
+  const size_t leading_zero_size           = sizeof(leading_zero);
+
+  // Act & Assert
+  EXPECT_EQ(decodes_correctly("Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi", byron_mainnet_yoroi, byron_mainnet_yoroi_size), true);
+  EXPECT_EQ(decodes_correctly("37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT", byron_testnet_daedalus, byron_testnet_daedalus_size), true);
+  EXPECT_EQ(decodes_correctly("2mkQLxaN3Y4CwN5E9rdMWNgsXX7VS6UnfeT", b58_high, b58_high_size), true);
+  EXPECT_EQ(decodes_correctly("19DXstMaV43WpYg4ceREiiTv2UntmoiA9j", leading_zero, leading_zero_size), true);
+}
+
+TEST(cardano_encoding_base58_get_encoded_length, returnZeroIfGivenNullPtr)
+{
+  // Arrange
+  const byte_t* data        = NULL;
+  const size_t  data_length = 0;
+
+  // Act
+  size_t encoded_length = cardano_encoding_base58_get_encoded_length(data, data_length);
+
+  // Assert
+  EXPECT_EQ(encoded_length, 0);
+}
+
+TEST(cardano_encoding_base58_get_encoded_length, returnEmptyStringIfGivenEmptyData)
+{
+  // Arrange
+  const byte_t* data        = (byte_t*)"";
+  const size_t  data_length = 0;
+
+  // Act
+  size_t encoded_length = cardano_encoding_base58_get_encoded_length(data, data_length);
+
+  // Assert
+  EXPECT_EQ(encoded_length, 1);
+}
+
+TEST(cardano_encoding_base58_get_decoded_length, returnZeroIfGivenNullPtr)
+{
+  // Arrange
+  const char*  data        = NULL;
+  const size_t data_length = 0;
+
+  // Act
+  size_t decoded_length = cardano_encoding_base58_get_decoded_length(data, data_length);
+
+  // Assert
+  EXPECT_EQ(decoded_length, 0);
+}
+
+TEST(cardano_encoding_base58_get_decoded_length, returnZeroIfGivenEmptyString)
+{
+  // Arrange
+  const char*  data        = "";
+  const size_t data_length = 0;
+
+  // Act
+  size_t decoded_length = cardano_encoding_base58_get_decoded_length(data, data_length);
+
+  // Assert
+  EXPECT_EQ(decoded_length, 0);
+}
+
+TEST(cardano_encoding_base58_encode, returnPointerIsNullIfGivenNullPtr)
+{
+  // Arrange
+  const byte_t* data          = NULL;
+  const size_t  data_length   = 0;
+  char*         output        = NULL;
+  const size_t  output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_encoding_base58_encode, returnInsufficientBufferSizeIfGivenEmptyData)
+{
+  // Arrange
+  const byte_t* data          = (byte_t*)"";
+  const size_t  data_length   = 0;
+  char*         output        = (char*)malloc(1);
+  const size_t  output_length = 1;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_encode, returnPointerIsNullIfGivenNullOutput)
+{
+  // Arrange
+  const byte_t* data          = (byte_t*)"";
+  const size_t  data_length   = 1;
+  char*         output        = NULL;
+  const size_t  output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_encoding_base58_encode, returnInsufficientBufferSizeIfGivenEmptyOutput)
+{
+  // Arrange
+  const byte_t* data          = (byte_t*)"";
+  const size_t  data_length   = 0;
+  char*         output        = (char*)malloc(1);
+  const size_t  output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_encode, returnInsufficientBufferSizeIfGivenSmallOutputLength)
+{
+  // Arrange
+  const byte_t* data          = (byte_t*)"Hello, World!";
+  const size_t  data_length   = strlen((const char*)data);
+  char*         output        = (char*)malloc(1);
+  const size_t  output_length = 1;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_encode, returnErrorIfMemoryAllocationFails)
+{
+  // Arrange
+  const byte_t* data          = (byte_t*)"Hello, World!";
+  const size_t  data_length   = strlen((const char*)data);
+  byte_t        output_data[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_right_away_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_encode(data, data_length, (char*)output_data, 100);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_MEMORY_ALLOCATION_FAILED);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_base58_decode, returnPointerIsNullIfGivenNullPtr)
+{
+  // Arrange
+  const char*  data          = NULL;
+  const size_t data_length   = 0;
+  uint8_t*     output        = (uint8_t*)"";
+  const size_t output_length = 1;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_encoding_base58_decode, returnInsufficientBufferSizeIfGivenEmptyData)
+{
+  // Arrange
+  const char*  data          = "";
+  const size_t data_length   = 0;
+  uint8_t*     output        = (uint8_t*)malloc(1);
+  const size_t output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_decode, returnPointerIsNullIfGivenNullOutput)
+{
+  // Arrange
+  const char*  data          = "";
+  const size_t data_length   = 1;
+  uint8_t*     output        = NULL;
+  const size_t output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_POINTER_IS_NULL);
+}
+
+TEST(cardano_encoding_base58_decode, returnInsufficientBufferSizeIfGivenEmptyOutput)
+{
+  // Arrange
+  const char*  data          = "";
+  const size_t data_length   = 0;
+  uint8_t*     output        = (uint8_t*)malloc(1);
+  const size_t output_length = 0;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_decode, returnInsufficientBufferSizeIfGivenSmallOutputLength)
+{
+  // Arrange
+  const char*  data          = "Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi";
+  const size_t data_length   = strlen(data);
+  uint8_t*     output        = (uint8_t*)malloc(1);
+  const size_t output_length = 1;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_INSUFFICIENT_BUFFER_SIZE);
+
+  free(output);
+}
+
+TEST(cardano_encoding_base58_decode, returnEncodingErrorIfGivenAWrongCharacter)
+{
+  // Arrange
+  const char*  data          = "Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi!";
+  const size_t data_length   = strlen(data);
+  uint8_t*     output        = (uint8_t*)malloc(100);
+  const size_t output_length = 100;
+
+  // Act
+  cardano_error_t result = cardano_encoding_base58_decode(data, data_length, output, output_length);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_DECODING);
+
+  free(output);
+}

--- a/lib/tests/encoding/bech32.cpp
+++ b/lib/tests/encoding/bech32.cpp
@@ -1,0 +1,701 @@
+/**
+ * \file bech32.cpp
+ *
+ * \author angel.castillo
+ * \date   Apr 06, 2024
+ *
+ * Copyright 2024 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/encoding/bech32.h>
+#include <gmock/gmock.h>
+
+#include <cardano/allocators.h>
+
+#include "../allocators_helpers.h"
+
+#include <vector>
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Converts a hexadecimal string to a byte vector.
+ *
+ * \param hex The hexadecimal string.
+ *
+ * \return The byte vector.
+ */
+static auto
+hex_to_bytes(const std::string& hex) -> std::vector<byte_t>
+{
+  std::vector<byte_t> bytes;
+
+  for (size_t i = 0; i < hex.length(); i += 2)
+  {
+    std::string const byteString = hex.substr(i, 2);
+    auto              byte       = (byte_t)strtol(byteString.c_str(), nullptr, 16);
+    bytes.push_back(byte);
+  }
+
+  return bytes;
+}
+
+/**
+ * \brief Verifies that the Bech32 encoding of a given data is correct.
+ */
+static void
+verify_encode(const std::string& bech32, const std::string& hrp, const std::string& hex_data)
+{
+  // Arrange
+  const std::vector<byte_t> data = hex_to_bytes(hex_data);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hrp.c_str(), hrp.size(), data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hrp.c_str(), hrp.size(), data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(bech32_size, testing::Eq(bech32.size() + 1));
+  ASSERT_THAT(result, testing::Eq(CARDANO_SUCCESS));
+  ASSERT_THAT(bech32_string, testing::StrEq(bech32));
+
+  // Cleanup
+  free(bech32_string);
+}
+
+/**
+ * \brief Verifies that the Bech32 decoding of a given data is correct.
+ */
+static void
+verify_decode(const std::string& bech32, const std::string& expected_hrp, const std::string& hex_data)
+{
+  const std::vector<byte_t> expected_data = hex_to_bytes(hex_data);
+
+  // Act
+  size_t       hrp_size  = 0;
+  const size_t data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*      data      = (byte_t*)malloc(data_size);
+  char*        hrp       = (char*)malloc(hrp_size);
+
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  ASSERT_THAT(data_size, expected_data.size());
+  ASSERT_THAT(hrp_size, testing::Eq(expected_hrp.size() + 1));
+  ASSERT_THAT(result, testing::Eq(CARDANO_SUCCESS));
+  ASSERT_THAT(memcmp(data, &expected_data[0], data_size), testing::Eq(0));
+  ASSERT_THAT(strcmp(hrp, expected_hrp.c_str()), testing::Eq(0));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+}
+
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_encoding_bech32_decode, canDecodeBech32Strings)
+{
+  verify_decode("addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x", "addr", "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w", "addr", "6079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65");
+  verify_decode("stake1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egfu2p0u", "stake", "6079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65");
+  verify_decode("addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x", "addr", "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh", "addr", "11c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve", "addr", "219493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8ec37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g", "addr", "31c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542fc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k", "addr", "419493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e8198bd431b03");
+  verify_decode("addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu", "addr", "51c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f8198bd431b03");
+  verify_decode("addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8", "addr", "619493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e");
+  verify_decode("addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx", "addr", "71c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw", "stake", "e1337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5", "stake", "f1c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae", "addr_test", "009493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg", "addr_test", "10c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("addr_test1yz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shsf5r8qx", "addr_test", "209493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8ec37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("addr_test1xrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs4p04xh", "addr_test", "30c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542fc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky", "addr_test", "409493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e8198bd431b03");
+  verify_decode("addr_test12rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcryqrvmw", "addr_test", "50c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f8198bd431b03");
+  verify_decode("addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz", "addr_test", "609493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e");
+  verify_decode("addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr", "addr_test", "70c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn", "stake_test", "e0337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_decode("stake_test17rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcljw6kf", "stake_test", "f0c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_decode("A12UEL5L", "a", "");
+  verify_decode("an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs", "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio", "");
+  verify_decode("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", "abcdef", "00443214c74254b635cf84653a56d7c675be77df");
+  verify_decode("11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", "1", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+  verify_decode("split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", "split", "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d");
+}
+
+TEST(cardano_encoding_bech32_encode, canEncodeBech32Strings)
+{
+  verify_encode("addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x", "addr", "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w", "addr", "6079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65");
+  verify_encode("stake1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egfu2p0u", "stake", "6079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65");
+  verify_encode("addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x", "addr", "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh", "addr", "11c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve", "addr", "219493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8ec37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g", "addr", "31c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542fc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k", "addr", "419493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e8198bd431b03");
+  verify_encode("addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu", "addr", "51c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f8198bd431b03");
+  verify_encode("addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8", "addr", "619493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e");
+  verify_encode("addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx", "addr", "71c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw", "stake", "e1337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5", "stake", "f1c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae", "addr_test", "009493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg", "addr_test", "10c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("addr_test1yz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shsf5r8qx", "addr_test", "209493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8ec37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("addr_test1xrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs4p04xh", "addr_test", "30c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542fc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky", "addr_test", "409493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e8198bd431b03");
+  verify_encode("addr_test12rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcryqrvmw", "addr_test", "50c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f8198bd431b03");
+  verify_encode("addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz", "addr_test", "609493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e");
+  verify_encode("addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr", "addr_test", "70c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn", "stake_test", "e0337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  verify_encode("stake_test17rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcljw6kf", "stake_test", "f0c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+  verify_encode("a12uel5l", "a", "");
+  verify_encode("an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs", "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio", "");
+  verify_encode("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", "abcdef", "00443214c74254b635cf84653a56d7c675be77df");
+  verify_encode("11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", "1", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+  verify_encode("split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", "split", "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d");
+}
+
+TEST(cardano_encoding_bech32_encode, invalidBech32StringsReturnsError)
+{
+  std::vector<std::string> invalidChecksum = {
+    "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+    "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+    "bc1rw5uspcuh",
+    "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+    "stake_test1uyuqtqq84v9jrqm0asptaehtw7srrr7cnwuxyqz38a6e8scm6lcf3",
+    "addr_test1qxkmuf2gqzsm5ejxm2amrwuq3pcc02cw6tttgsgqgafj46klskg5jjufdyf4znw8sjn37enwn5ge5l66qsx8srrpg3tq8du7us",
+    "stake1ur84236ycjkxvt0r5l7tdqaatlhhec0hrpncqlv5gp58e0q2ajrqx",
+    "addr1qznd7jmvw2a53ykmgg5c6dcqd9f35mtts77zf57wn6ern5x024r5f39vvck78fluk6pm6hl00nslwxr8sp7egsrg0j7q8y2a9d",
+    "BC1QR508D6QEJXTdg4y5r3zarvaryv98gj9p",
+    "21ibccqr508d6qejxtdg4y5r3zarvar98gj9p",
+    "BCCQR508D6QEJXTdg4y5r3zarvaryv98gj9p",
+    "2"
+  };
+
+  for (size_t i = 0; i < invalidChecksum.size(); ++i)
+  {
+    const std::string bech32    = invalidChecksum[i];
+    size_t            hrp_size  = 0;
+    const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+    byte_t*           data      = (byte_t*)malloc(data_size);
+    char*             hrp       = (char*)malloc(hrp_size);
+
+    cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+    // Assert
+    EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+
+    // Cleanup
+    free(hrp);
+    free(data);
+  }
+}
+
+TEST(cardano_encoding_bech32_get_decoded_length, returnErrorIfBech32IsNull)
+{
+  // Act
+  size_t hrp_size  = 0;
+  size_t data_size = cardano_encoding_bech32_get_decoded_length(nullptr, 0, &hrp_size);
+
+  // Assert
+  EXPECT_THAT(data_size, testing::Eq(0));
+  EXPECT_THAT(hrp_size, testing::Eq(0));
+}
+
+TEST(cardano_encoding_bech32_get_decoded_length, returnErrorIfHrpIsNull)
+{
+  // Act
+  size_t data_size = cardano_encoding_bech32_get_decoded_length("", 0, nullptr);
+
+  // Assert
+  EXPECT_THAT(data_size, testing::Eq(0));
+}
+
+TEST(cardano_encoding_bech32_get_decoded_length, returnErrorIfDataIsNull)
+{
+  // Act
+  size_t data_size = cardano_encoding_bech32_get_decoded_length("", 1, nullptr);
+
+  // Assert
+  EXPECT_THAT(data_size, testing::Eq(0));
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfHrpIsNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_encode(nullptr, 0, (const byte_t*)"", 0, (char*)"", 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfDataIsNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_encode("", 0, nullptr, 10, (char*)"", 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfOutputNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_encode("", 0, (byte_t*)"", 0, nullptr, 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfOutputLengthIsZero)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_encode("", 0, (byte_t*)"", 0, (char*)"", 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfMemoryAllocationFails)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_right_away_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfOutputBufferIsTooSmall)
+{
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size - 1);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, 1);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_INSUFFICIENT_BUFFER_SIZE));
+
+  // Cleanup
+  free(bech32_string);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfEventualMemoryAllocationFails1)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_one_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfEventualMemoryAllocationFails2)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_two_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfEventualMemoryAllocationFails3)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_three_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfEventualMemoryAllocationFails4)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_four_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_encode, returnErrorIfEventualMemoryAllocationFails5)
+{
+  // Arrange
+  const std::vector<byte_t> data     = hex_to_bytes("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251");
+  const char*               hpr      = "addr";
+  const size_t              hrp_size = 0;
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_five_malloc, realloc, free);
+
+  // Act
+  const size_t bech32_size   = cardano_encoding_bech32_get_encoded_length(hpr, hrp_size, data.data(), data.size());
+  char*        bech32_string = (char*)malloc(bech32_size);
+
+  cardano_error_t result = cardano_encoding_bech32_encode(hpr, hrp_size, data.data(), data.size(), bech32_string, bech32_size);
+
+  // Assert
+  ASSERT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(bech32_string);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfInputIsNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(nullptr, 0, (char*)"", 0, (byte_t*)"", 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfHrpIsNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode((char*)"", 0, nullptr, 0, (byte_t*)"", 0);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfDataIsNull)
+{
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode("", 0, (char*)"", 0, nullptr, 10);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfDecodedLengthIsLessThanOutputLength)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size - 1);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfMemoryAllocationFails)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_right_away_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails1)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_one_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_ERROR_DECODING));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails2)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_two_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_ERROR_DECODING));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails3)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_three_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_ERROR_DECODING));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails4)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_four_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_ERROR_DECODING));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails5)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_five_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_ERROR_DECODING));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfEventualMemoryAllocationFails6)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size);
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_six_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Eq(CARDANO_MEMORY_ALLOCATION_FAILED));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+}
+
+TEST(cardano_encoding_bech32_decode, returnErrorIfHrpBufferIsTooSmall)
+{
+  // Arrange
+  const std::string bech32    = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+  size_t            hrp_size  = 0;
+  const size_t      data_size = cardano_encoding_bech32_get_decoded_length(bech32.c_str(), bech32.size(), &hrp_size);
+  byte_t*           data      = (byte_t*)malloc(data_size);
+  char*             hrp       = (char*)malloc(hrp_size - 1);
+
+  // Act
+  cardano_error_t result = cardano_encoding_bech32_decode(bech32.c_str(), bech32.size(), hrp, hrp_size - 1, data, data_size);
+
+  // Assert
+  EXPECT_THAT(result, testing::Not(CARDANO_SUCCESS));
+
+  // Cleanup
+  free(hrp);
+  free(data);
+}


### PR DESCRIPTION
## Description

We must implement the encoding/decoding algorithms base58 and bech32 before we can implement address parsing and encoding.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [X] I have added tests
    - [X] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?