### PR TITLE
doc: fix ibjsonc link in docs

### DIFF
--- a/doc/src/sections/index.rst
+++ b/doc/src/sections/index.rst
@@ -33,7 +33,7 @@ Main features
 - No shared global state - threading friendly
 - Proper handling of UTF-8
 - Extensive documentation and test suite
-- It has no runtime dependencies (The library depends on `libsodium`_ and `_libjsonc`_ but they are both statically linked)
+- It has no runtime dependencies (The library depends on `libsodium`_ and `libjsonc`_ but they are both statically linked)
 
 Engineered for Excellence
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

Fix boken link for jsonc

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [ ] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?