### PR TITLE
chore: remove move semantics from all objects

### DIFF
--- a/doc/src/sections/api/address/address.rst
+++ b/doc/src/sections/api/address/address.rst
@@ -53,10 +53,6 @@ Address
 
 ------------
 
-.. doxygenfunction:: cardano_address_move
-
-------------
-
 .. doxygenfunction:: cardano_address_ref
 
 ------------

--- a/doc/src/sections/api/address/base_address.rst
+++ b/doc/src/sections/api/address/base_address.rst
@@ -49,10 +49,6 @@ Base Address
 
 ------------
 
-.. doxygenfunction:: cardano_base_address_move
-
-------------
-
 .. doxygenfunction:: cardano_base_address_ref
 
 ------------

--- a/doc/src/sections/api/address/byron_address.rst
+++ b/doc/src/sections/api/address/byron_address.rst
@@ -53,10 +53,6 @@ Byron Address
 
 ------------
 
-.. doxygenfunction:: cardano_byron_address_move
-
-------------
-
 .. doxygenfunction:: cardano_byron_address_ref
 
 ------------

--- a/doc/src/sections/api/address/enterprise_address.rst
+++ b/doc/src/sections/api/address/enterprise_address.rst
@@ -45,10 +45,6 @@ Enterprise Address
 
 ------------
 
-.. doxygenfunction:: cardano_enterprise_address_move
-
-------------
-
 .. doxygenfunction:: cardano_enterprise_address_ref
 
 ------------

--- a/doc/src/sections/api/address/pointer_address.rst
+++ b/doc/src/sections/api/address/pointer_address.rst
@@ -49,10 +49,6 @@ Pointer Address
 
 ------------
 
-.. doxygenfunction:: cardano_pointer_address_move
-
-------------
-
 .. doxygenfunction:: cardano_pointer_address_ref
 
 ------------

--- a/doc/src/sections/api/address/reward_address.rst
+++ b/doc/src/sections/api/address/reward_address.rst
@@ -45,10 +45,6 @@ Reward Address
 
 ------------
 
-.. doxygenfunction:: cardano_reward_address_move
-
-------------
-
 .. doxygenfunction:: cardano_reward_address_ref
 
 ------------

--- a/doc/src/sections/api/buffer.rst
+++ b/doc/src/sections/api/buffer.rst
@@ -53,10 +53,6 @@ Buffer
 
 ------------
 
-.. doxygenfunction:: cardano_buffer_move
-
-------------
-
 .. doxygenfunction:: cardano_buffer_get_data
 
 ------------

--- a/doc/src/sections/api/cbor/cbor_reader.rst
+++ b/doc/src/sections/api/cbor/cbor_reader.rst
@@ -25,10 +25,6 @@ CBOR Reader
 
 ------------
 
-.. doxygenfunction:: cardano_cbor_reader_move
-
-------------
-
 .. doxygenfunction:: cardano_cbor_reader_peek_state
 
 ------------

--- a/doc/src/sections/api/cbor/cbor_writer.rst
+++ b/doc/src/sections/api/cbor/cbor_writer.rst
@@ -21,10 +21,6 @@ CBOR Writer
 
 ------------
 
-.. doxygenfunction:: cardano_cbor_writer_move
-
-------------
-
 .. doxygenfunction:: cardano_cbor_writer_write_big_integer
 
 ------------

--- a/doc/src/sections/api/common/credential.rst
+++ b/doc/src/sections/api/common/credential.rst
@@ -37,10 +37,6 @@ Credential
 
 ------------
 
-.. doxygenfunction:: cardano_credential_move
-
-------------
-
 .. doxygenfunction:: cardano_credential_new
 
 ------------

--- a/doc/src/sections/api/cryptography/bip32_private_key.rst
+++ b/doc/src/sections/api/cryptography/bip32_private_key.rst
@@ -29,10 +29,6 @@ BIP32 Private Key
 
 ------------
 
-.. doxygenfunction:: cardano_bip32_private_key_move
-
-------------
-
 .. doxygenfunction:: cardano_bip32_private_key_derive
 
 ------------

--- a/doc/src/sections/api/cryptography/bip32_public_key.rst
+++ b/doc/src/sections/api/cryptography/bip32_public_key.rst
@@ -25,11 +25,6 @@ BIP32 Public Key
 
 ------------
 
-.. doxygenfunction:: cardano_bip32_public_key_move
-
-
-------------
-
 .. doxygenfunction:: cardano_bip32_public_key_derive
 
 

--- a/doc/src/sections/api/cryptography/blake2b_hash.rst
+++ b/doc/src/sections/api/cryptography/blake2b_hash.rst
@@ -29,10 +29,6 @@ BLAKE2b Hash
 
 ------------
 
-.. doxygenfunction:: cardano_blake2b_hash_move
-
-------------
-
 .. doxygenfunction:: cardano_blake2b_hash_get_data
 
 ------------

--- a/doc/src/sections/api/cryptography/ed25519_private_key.rst
+++ b/doc/src/sections/api/cryptography/ed25519_private_key.rst
@@ -31,11 +31,6 @@ ED25519 Private Key
 
 .. doxygenfunction:: cardano_ed25519_private_key_refcount
 
-
-------------
-
-.. doxygenfunction:: cardano_ed25519_private_key_move
-
 ------------
 
 .. doxygenfunction:: cardano_ed25519_private_key_sign

--- a/doc/src/sections/api/cryptography/ed25519_public_key.rst
+++ b/doc/src/sections/api/cryptography/ed25519_public_key.rst
@@ -25,10 +25,6 @@ ED25519 Public Key
 
 ------------
 
-.. doxygenfunction:: cardano_ed25519_public_key_move
-
-------------
-
 .. doxygenfunction:: cardano_ed25519_public_verify
 
 ------------

--- a/doc/src/sections/api/cryptography/ed25519_signature.rst
+++ b/doc/src/sections/api/cryptography/ed25519_signature.rst
@@ -25,10 +25,6 @@ ED25519 Signature
 
 ------------
 
-.. doxygenfunction:: cardano_ed25519_signature_move
-
-------------
-
 .. doxygenfunction:: cardano_ed25519_signature_get_data
 
 ------------

--- a/doc/src/sections/api/object.rst
+++ b/doc/src/sections/api/object.rst
@@ -17,10 +17,6 @@ Object
 
 ------------
 
-.. doxygenfunction:: cardano_object_move
-
-------------
-
 .. doxygenfunction:: cardano_object_set_last_error
 
 ------------

--- a/lib/include/cardano/address/address.h
+++ b/lib/include/cardano/address/address.h
@@ -805,19 +805,6 @@ CARDANO_EXPORT void cardano_address_ref(cardano_address_t* address);
 CARDANO_EXPORT size_t cardano_address_refcount(const cardano_address_t* address);
 
 /**
- * \brief Moves a address, decrementing its reference count without deallocating.
- *
- * Useful for transferring address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address address to be moved.
- * \return The address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_address_t* cardano_address_move(cardano_address_t* address);
-
-/**
  * \brief Sets the last error message for a given address.
  *
  * This function records an error message in the address's last_error buffer,

--- a/lib/include/cardano/address/base_address.h
+++ b/lib/include/cardano/address/base_address.h
@@ -594,19 +594,6 @@ CARDANO_EXPORT void cardano_base_address_ref(cardano_base_address_t* address);
 CARDANO_EXPORT size_t cardano_base_address_refcount(const cardano_base_address_t* address);
 
 /**
- * \brief Moves a base address, decrementing its reference count without deallocating.
- *
- * Useful for transferring base address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address base address to be moved.
- * \return The base address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_base_address_t* cardano_base_address_move(cardano_base_address_t* address);
-
-/**
  * \brief Sets the last error message for a given base address.
  *
  * This function records an error message in the base address's last_error buffer,

--- a/lib/include/cardano/address/byron_address.h
+++ b/lib/include/cardano/address/byron_address.h
@@ -648,19 +648,6 @@ CARDANO_EXPORT void cardano_byron_address_ref(cardano_byron_address_t* address);
 CARDANO_EXPORT size_t cardano_byron_address_refcount(const cardano_byron_address_t* address);
 
 /**
- * \brief Moves a byron address, decrementing its reference count without deallocating.
- *
- * Useful for transferring byron address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address byron address to be moved.
- * \return The byron address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_byron_address_t* cardano_byron_address_move(cardano_byron_address_t* address);
-
-/**
  * \brief Sets the last error message for a given byron address.
  *
  * This function records an error message in the byron address's last_error buffer,

--- a/lib/include/cardano/address/enterprise_address.h
+++ b/lib/include/cardano/address/enterprise_address.h
@@ -582,19 +582,6 @@ CARDANO_EXPORT void cardano_enterprise_address_ref(cardano_enterprise_address_t*
 CARDANO_EXPORT size_t cardano_enterprise_address_refcount(const cardano_enterprise_address_t* address);
 
 /**
- * \brief Moves a enterprise address, decrementing its reference count without deallocating.
- *
- * Useful for transferring enterprise address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address enterprise address to be moved.
- * \return The enterprise address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_enterprise_address_t* cardano_enterprise_address_move(cardano_enterprise_address_t* address);
-
-/**
  * \brief Sets the last error message for a given enterprise address.
  *
  * This function records an error message in the enterprise address's last_error buffer,

--- a/lib/include/cardano/address/pointer_address.h
+++ b/lib/include/cardano/address/pointer_address.h
@@ -630,19 +630,6 @@ CARDANO_EXPORT void cardano_pointer_address_ref(cardano_pointer_address_t* addre
 CARDANO_EXPORT size_t cardano_pointer_address_refcount(const cardano_pointer_address_t* address);
 
 /**
- * \brief Moves a pointer address, decrementing its reference count without deallocating.
- *
- * Useful for transferring pointer address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address pointer address to be moved.
- * \return The pointer address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_pointer_address_t* cardano_pointer_address_move(cardano_pointer_address_t* address);
-
-/**
  * \brief Sets the last error message for a given pointer address.
  *
  * This function records an error message in the pointer address's last_error buffer,

--- a/lib/include/cardano/address/reward_address.h
+++ b/lib/include/cardano/address/reward_address.h
@@ -565,19 +565,6 @@ CARDANO_EXPORT void cardano_reward_address_ref(cardano_reward_address_t* address
 CARDANO_EXPORT size_t cardano_reward_address_refcount(const cardano_reward_address_t* address);
 
 /**
- * \brief Moves a reward address, decrementing its reference count without deallocating.
- *
- * Useful for transferring reward address ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] address reward address to be moved.
- * \return The reward address with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_reward_address_t* cardano_reward_address_move(cardano_reward_address_t* address);
-
-/**
  * \brief Sets the last error message for a given reward address.
  *
  * This function records an error message in the reward address's last_error buffer,

--- a/lib/include/cardano/buffer.h
+++ b/lib/include/cardano/buffer.h
@@ -358,27 +358,6 @@ CARDANO_EXPORT void cardano_buffer_ref(cardano_buffer_t* buffer);
 CARDANO_EXPORT size_t cardano_buffer_refcount(const cardano_buffer_t* buffer);
 
 /**
- * \brief Moves a buffer, decrementing its reference count without deallocating it.
- *
- * This function is designed for transferring ownership of a buffer to another context where the reference
- * count will be managed (typically increased).
- *
- * \warning Improper management of the reference count after using this function can result in memory leaks. It is
- * critical to ensure that any function or process that takes ownership of the buffer subsequently manages the
- * reference count appropriately (e.g., by incrementing it if the buffer is retained).
- *
- * \param[in] buffer The buffer instance to be moved. The function decreases its reference count by one, but
- * does not deallocate the buffer even if its reference count reaches zero. This behavior supports the transfer
- * of ownership semantics by allowing the new owner to safely increase the reference count.
- *
- * \return Returns the buffer instance with its reference count decremented. The caller becomes the new owner
- * of the buffer and is responsible for its lifecycle management, including properly incrementing the reference
- * count if the buffer is retained and eventually decrementing it to ensure proper deallocation.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_buffer_t* cardano_buffer_move(cardano_buffer_t* buffer);
-
-/**
  * \brief Retrieves a direct pointer to the internal data of a buffer.
  *
  * This function provides access to the internal storage of the buffer, allowing for read-only operations on its contents.

--- a/lib/include/cardano/cbor/cbor_reader.h
+++ b/lib/include/cardano/cbor/cbor_reader.h
@@ -189,26 +189,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_cbor_reader_refcount(const cardano_cbor_reader_t* cbor_reader);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_cbor_reader_t object.
- *
- * This function decreases the reference count of the specified CBOR reader object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_cbor_reader_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param cbor_reader A pointer to the CBOR reader object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_cbor_reader_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_cbor_reader_t* cardano_cbor_reader_move(cardano_cbor_reader_t* cbor_reader);
-
-/**
  * \brief Reads the next CBOR token from the reader without advancing the reader's internal position.
  *
  * This function examines the next CBOR token in the data stream, allowing the caller to inspect

--- a/lib/include/cardano/cbor/cbor_writer.h
+++ b/lib/include/cardano/cbor/cbor_writer.h
@@ -158,26 +158,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_cbor_writer_refcount(const cardano_cbor_writer_t* cbor_writer);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_cbor_writer_t object.
- *
- * This function decreases the reference count of the specified CBOR writer object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_cbor_writer_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param cbor_writer A pointer to the CBOR writer object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_cbor_writer_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_cbor_writer_t* cardano_cbor_writer_move(cardano_cbor_writer_t* cbor_writer);
-
-/**
  * \brief Encodes and writes an unsigned integer value as a tagged big number (bignum) in CBOR format.
  *
  * This function writes a provided unsigned integer value as a bignum, following the

--- a/lib/include/cardano/common/credential.h
+++ b/lib/include/cardano/common/credential.h
@@ -496,26 +496,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_credential_refcount(const cardano_credential_t* credential);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_credential_t object.
- *
- * This function decreases the reference count of the specified credential object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_credential_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param credential A pointer to the credential object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_credential_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_credential_t* cardano_credential_move(cardano_credential_t* credential);
-
-/**
  * \brief Sets the last error message for a given credential object.
  *
  * Records an error message in the credential's last_error buffer, overwriting any existing message.

--- a/lib/include/cardano/crypto/bip32_private_key.h
+++ b/lib/include/cardano/crypto/bip32_private_key.h
@@ -262,27 +262,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_bip32_private_key_refcount(const cardano_bip32_private_key_t* private_key);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_bip32_private_key_t object.
- *
- * This function decreases the reference count of the specified BIP32 private key object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_bip32_private_key_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param[in] private_key A pointer to the BIP32 private key object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_bip32_private_key_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_bip32_private_key_t* cardano_bip32_private_key_move(
-  cardano_bip32_private_key_t* private_key);
-
-/**
  * \brief Derives a child BIP32 private key from a parent BIP32 private key using a specified derivation path.
  *
  * This function takes a BIP32 private key and an array of indices representing the derivation path

--- a/lib/include/cardano/crypto/bip32_public_key.h
+++ b/lib/include/cardano/crypto/bip32_public_key.h
@@ -207,26 +207,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_bip32_public_key_refcount(const cardano_bip32_public_key_t* public_key);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_bip32_public_key_t object.
- *
- * This function decreases the reference count of the specified BIP32 public key object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_bip32_public_key_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param public_key A pointer to the BIP32 public key object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_bip32_public_key_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_bip32_public_key_t* cardano_bip32_public_key_move(cardano_bip32_public_key_t* public_key);
-
-/**
  * \brief Derives a BIP32 public key based on a sequence of indices.
  *
  * This function takes an existing BIP32 public key and derives a new public key

--- a/lib/include/cardano/crypto/blake2b_hash.h
+++ b/lib/include/cardano/crypto/blake2b_hash.h
@@ -252,26 +252,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_blake2b_hash_refcount(const cardano_blake2b_hash_t* hash);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_blake2b_hash_t object.
- *
- * This function decreases the reference count of the specified BLAKE2b hash object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_blake2b_hash_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param[in,out] hash A pointer to the BLAKE2b hash object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_blake2b_hash_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_blake2b_hash_t* cardano_blake2b_hash_move(cardano_blake2b_hash_t* hash);
-
-/**
  * \brief Retrieves a direct pointer to the internal data of a blake2b hash object.
  *
  * This function provides access to the internal storage of the blake2b hash object, allowing for read-only operations on its contents.

--- a/lib/include/cardano/crypto/ed25519_private_key.h
+++ b/lib/include/cardano/crypto/ed25519_private_key.h
@@ -306,26 +306,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_ed25519_private_key_refcount(const cardano_ed25519_private_key_t* private_key);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_ed25519_private_key_t object.
- *
- * This function decreases the reference count of the specified Ed25519 private key object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_ed25519_private_key_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param[in,out] private_key A pointer to the Ed25519 private key object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_ed25519_private_key_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_ed25519_private_key_t* cardano_ed25519_private_key_move(cardano_ed25519_private_key_t* private_key);
-
-/**
  * \brief Signs a message using an Ed25519 private key.
  *
  * This function creates a digital signature for a specified message using the provided

--- a/lib/include/cardano/crypto/ed25519_public_key.h
+++ b/lib/include/cardano/crypto/ed25519_public_key.h
@@ -208,27 +208,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_ed25519_public_key_refcount(const cardano_ed25519_public_key_t* public_key);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_ed25519_public_key_t object.
- *
- * This function decreases the reference count of the specified Ed25519 public key object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_ed25519_public_key_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param[in,out] public_key A pointer to the Ed25519 public key object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_ed25519_public_key_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_ed25519_public_key_t* cardano_ed25519_public_key_move(
-  cardano_ed25519_public_key_t* public_key);
-
-/**
  * \brief Verifies a signature against a message using an Ed25519 public key.
  *
  * This function checks if the given signature is valid for the specified message

--- a/lib/include/cardano/crypto/ed25519_signature.h
+++ b/lib/include/cardano/crypto/ed25519_signature.h
@@ -201,26 +201,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_ed25519_signature_refcount(const cardano_ed25519_signature_t* signature);
 
 /**
- * \brief Implements a C++-like move construct for the cardano_ed25519_signature_t object.
- *
- * This function decreases the reference count of the specified Ed25519 signature object by one,
- * but does not deallocate the object, even if its reference count reaches zero. It is designed
- * for transferring ownership of an object to another part of the code, which is expected to
- * subsequently increase the reference count (e.g., by calling \ref cardano_ed25519_signature_ref).
- *
- * \warning Improper use of this function can lead to memory leaks. Ensure that the reference
- *          count is correctly managed after moving the object to avoid leaking resources.
- *
- * \param[in,out] signature A pointer to the Ed25519 signature object to be moved. The reference count of this
- *                    object is decreased by one.
- * \return The same \ref cardano_ed25519_signature_t object passed as the parameter, with its reference count
- *         decreased by one. If the caller fails to manage the reference count properly after
- *         the move, it may lead to memory leaks.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_ed25519_signature_t* cardano_ed25519_signature_move(cardano_ed25519_signature_t* signature);
-
-/**
  * \brief Retrieves a direct pointer to the internal data of a Ed25519 signature object.
  *
  * This function provides access to the internal storage of the Ed25519 signature object, allowing for read-only operations on its contents.

--- a/lib/include/cardano/object.h
+++ b/lib/include/cardano/object.h
@@ -91,19 +91,6 @@ CARDANO_EXPORT void cardano_object_ref(cardano_object_t* object);
 CARDANO_EXPORT size_t cardano_object_refcount(const cardano_object_t* object);
 
 /**
- * \brief Moves a object, decrementing its reference count without deallocating.
- *
- * Useful for transferring object ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] object object to be moved.
- * \return The object with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_object_t* cardano_object_move(cardano_object_t* object);
-
-/**
  * \brief Sets the last error message for a given object.
  *
  * This function records an error message in the object's last_error buffer,

--- a/lib/src/address/address.c
+++ b/lib/src/address/address.c
@@ -579,21 +579,6 @@ cardano_address_refcount(const cardano_address_t* address)
   return cardano_object_refcount(&address->base);
 }
 
-cardano_address_t*
-cardano_address_move(cardano_address_t* address)
-{
-  if (address == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&address->base);
-
-  CARDANO_UNUSED(object);
-
-  return address;
-}
-
 void
 cardano_address_set_last_error(cardano_address_t* address, const char* message)
 {

--- a/lib/src/address/base_address.c
+++ b/lib/src/address/base_address.c
@@ -361,12 +361,6 @@ cardano_base_address_refcount(const cardano_base_address_t* address)
   return cardano_address_refcount(_cardano_from_base_to_address_const(address));
 }
 
-cardano_base_address_t*
-cardano_base_address_move(cardano_base_address_t* address)
-{
-  return _cardano_from_address_to_base(cardano_address_move(_cardano_from_base_to_address(address)));
-}
-
 void
 cardano_base_address_set_last_error(cardano_base_address_t* address, const char* message)
 {

--- a/lib/src/address/byron_address.c
+++ b/lib/src/address/byron_address.c
@@ -363,12 +363,6 @@ cardano_byron_address_refcount(const cardano_byron_address_t* address)
   return cardano_address_refcount(_cardano_from_byron_to_address_const(address));
 }
 
-cardano_byron_address_t*
-cardano_byron_address_move(cardano_byron_address_t* address)
-{
-  return _cardano_from_address_to_byron(cardano_address_move(_cardano_from_byron_to_address(address)));
-}
-
 void
 cardano_byron_address_set_last_error(cardano_byron_address_t* address, const char* message)
 {

--- a/lib/src/address/enterprise_address.c
+++ b/lib/src/address/enterprise_address.c
@@ -323,12 +323,6 @@ cardano_enterprise_address_refcount(const cardano_enterprise_address_t* address)
   return cardano_address_refcount(_cardano_from_enterprise_to_address_const(address));
 }
 
-cardano_enterprise_address_t*
-cardano_enterprise_address_move(cardano_enterprise_address_t* address)
-{
-  return _cardano_from_address_to_enterprise(cardano_address_move(_cardano_from_enterprise_to_address(address)));
-}
-
 void
 cardano_enterprise_address_set_last_error(cardano_enterprise_address_t* address, const char* message)
 {

--- a/lib/src/address/pointer_address.c
+++ b/lib/src/address/pointer_address.c
@@ -338,12 +338,6 @@ cardano_pointer_address_refcount(const cardano_pointer_address_t* address)
   return cardano_address_refcount(_cardano_from_pointer_to_address_const(address));
 }
 
-cardano_pointer_address_t*
-cardano_pointer_address_move(cardano_pointer_address_t* address)
-{
-  return _cardano_from_address_to_pointer(cardano_address_move(_cardano_from_pointer_to_address(address)));
-}
-
 void
 cardano_pointer_address_set_last_error(cardano_pointer_address_t* address, const char* message)
 {

--- a/lib/src/address/reward_address.c
+++ b/lib/src/address/reward_address.c
@@ -322,12 +322,6 @@ cardano_reward_address_refcount(const cardano_reward_address_t* address)
   return cardano_address_refcount(_cardano_from_reward_to_address_const(address));
 }
 
-cardano_reward_address_t*
-cardano_reward_address_move(cardano_reward_address_t* address)
-{
-  return _cardano_from_address_to_reward(cardano_address_move(_cardano_from_reward_to_address(address)));
-}
-
 void
 cardano_reward_address_set_last_error(cardano_reward_address_t* address, const char* message)
 {

--- a/lib/src/buffer/buffer.c
+++ b/lib/src/buffer/buffer.c
@@ -473,20 +473,6 @@ cardano_buffer_refcount(const cardano_buffer_t* buffer)
   return cardano_object_refcount(&buffer->base);
 }
 
-cardano_buffer_t*
-cardano_buffer_move(cardano_buffer_t* buffer)
-{
-  if (buffer == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&buffer->base);
-  CARDANO_UNUSED(object);
-
-  return buffer;
-}
-
 byte_t*
 cardano_buffer_get_data(const cardano_buffer_t* buffer)
 {

--- a/lib/src/cbor/cbor_reader/cbor_reader.c
+++ b/lib/src/cbor/cbor_reader/cbor_reader.c
@@ -210,21 +210,6 @@ cardano_cbor_reader_refcount(const cardano_cbor_reader_t* cbor_reader)
   return cardano_object_refcount(&cbor_reader->base);
 }
 
-cardano_cbor_reader_t*
-cardano_cbor_reader_move(cardano_cbor_reader_t* cbor_reader)
-{
-  if (cbor_reader == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&cbor_reader->base);
-
-  CARDANO_UNUSED(object);
-
-  return cbor_reader;
-}
-
 cardano_error_t
 cardano_cbor_reader_peek_state(cardano_cbor_reader_t* reader, cardano_cbor_reader_state_t* state)
 {

--- a/lib/src/cbor/cbor_writer.c
+++ b/lib/src/cbor/cbor_writer.c
@@ -231,21 +231,6 @@ cardano_cbor_writer_refcount(const cardano_cbor_writer_t* cbor_writer)
   return cardano_object_refcount(&cbor_writer->base);
 }
 
-cardano_cbor_writer_t*
-cardano_cbor_writer_move(cardano_cbor_writer_t* cbor_writer)
-{
-  if (cbor_writer == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&cbor_writer->base);
-
-  CARDANO_UNUSED(object);
-
-  return cbor_writer;
-}
-
 cardano_error_t
 cardano_cbor_writer_write_big_integer(cardano_cbor_writer_t* writer, const uint64_t value)
 {

--- a/lib/src/collections/array.c
+++ b/lib/src/collections/array.c
@@ -354,21 +354,6 @@ cardano_array_refcount(const cardano_array_t* array)
   return cardano_object_refcount(&array->base);
 }
 
-cardano_array_t*
-cardano_array_move(cardano_array_t* array)
-{
-  if (array == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&array->base);
-
-  CARDANO_UNUSED(object);
-
-  return array;
-}
-
 cardano_object_t*
 cardano_array_get(const cardano_array_t* array, const size_t index)
 {

--- a/lib/src/collections/array.h
+++ b/lib/src/collections/array.h
@@ -147,19 +147,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_array_refcount(const cardano_array_t* array);
 
 /**
- * \brief Moves a array, decrementing its reference count without deallocating.
- *
- * Useful for transferring array ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] array Array to be moved.
- * \return The array with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_array_t* cardano_array_move(cardano_array_t* array);
-
-/**
  * \brief Fetches a direct pointer to the array's data.
  *
  * \warning This returns a pointer to the internal data, not a copy. Do not manually deallocate.

--- a/lib/src/collections/set.c
+++ b/lib/src/collections/set.c
@@ -148,15 +148,18 @@ cardano_set_from_array(cardano_array_t* array, cardano_set_compare_item_t compar
 
   for (size_t i = 0; i < cardano_array_get_size(array); ++i)
   {
-    cardano_object_t* item = cardano_object_move(cardano_array_get(array, i));
+    cardano_object_t* item = cardano_array_get(array, i);
 
     assert(item != NULL);
 
     if (cardano_set_add(set, item) == 0U)
     {
       cardano_set_unref(&set);
+      cardano_object_unref(&item);
       return NULL;
     }
+
+    cardano_object_unref(&item);
   }
 
   return set;
@@ -200,21 +203,6 @@ cardano_set_refcount(const cardano_set_t* set)
   }
 
   return cardano_object_refcount(&set->base);
-}
-
-cardano_set_t*
-cardano_set_move(cardano_set_t* set)
-{
-  if (set == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&set->base);
-
-  CARDANO_UNUSED(object);
-
-  return set;
 }
 
 size_t

--- a/lib/src/collections/set.h
+++ b/lib/src/collections/set.h
@@ -156,19 +156,6 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_set_refcount(const cardano_set_t* set);
 
 /**
- * \brief Moves a set, decrementing its reference count without deallocating.
- *
- * Useful for transferring set ownership to functions that will increase the reference count.
- *
- * \warning Memory will leak if the reference count isn't properly managed after a move.
- *
- * \param[in] set Set to be moved.
- * \return The set with its reference count decremented.
- */
-CARDANO_NODISCARD
-CARDANO_EXPORT cardano_set_t* cardano_set_move(cardano_set_t* set);
-
-/**
  * \brief Fetches a direct pointer to the set's data.
  *
  * \warning This returns a pointer to the internal data, not a copy. Do not manually deallocate.

--- a/lib/src/common/credential.c
+++ b/lib/src/common/credential.c
@@ -424,21 +424,6 @@ cardano_credential_refcount(const cardano_credential_t* credential)
   return cardano_object_refcount(&credential->base);
 }
 
-cardano_credential_t*
-cardano_credential_move(cardano_credential_t* credential)
-{
-  if (credential == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&credential->base);
-
-  CARDANO_UNUSED(object);
-
-  return credential;
-}
-
 void
 cardano_credential_set_last_error(cardano_credential_t* credential, const char* message)
 {

--- a/lib/src/crypto/bip32_private_key.c
+++ b/lib/src/crypto/bip32_private_key.c
@@ -311,21 +311,6 @@ cardano_bip32_private_key_refcount(const cardano_bip32_private_key_t* bip32_priv
   return cardano_object_refcount(&bip32_private_key->base);
 }
 
-cardano_bip32_private_key_t*
-cardano_bip32_private_key_move(cardano_bip32_private_key_t* bip32_private_key)
-{
-  if (bip32_private_key == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&bip32_private_key->base);
-
-  CARDANO_UNUSED(object);
-
-  return bip32_private_key;
-}
-
 cardano_error_t
 cardano_bip32_private_key_derive(
   const cardano_bip32_private_key_t* private_key,

--- a/lib/src/crypto/bip32_public_key.c
+++ b/lib/src/crypto/bip32_public_key.c
@@ -218,21 +218,6 @@ cardano_bip32_public_key_refcount(const cardano_bip32_public_key_t* bip32_public
   return cardano_object_refcount(&bip32_public_key->base);
 }
 
-cardano_bip32_public_key_t*
-cardano_bip32_public_key_move(cardano_bip32_public_key_t* bip32_public_key)
-{
-  if (bip32_public_key == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&bip32_public_key->base);
-
-  CARDANO_UNUSED(object);
-
-  return bip32_public_key;
-}
-
 cardano_error_t
 cardano_bip32_public_key_derive(
   const cardano_bip32_public_key_t* bip32_public_key,

--- a/lib/src/crypto/blake2b_hash.c
+++ b/lib/src/crypto/blake2b_hash.c
@@ -309,21 +309,6 @@ cardano_blake2b_hash_refcount(const cardano_blake2b_hash_t* blake2b_hash)
   return cardano_object_refcount(&blake2b_hash->base);
 }
 
-cardano_blake2b_hash_t*
-cardano_blake2b_hash_move(cardano_blake2b_hash_t* blake2b_hash)
-{
-  if (blake2b_hash == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&blake2b_hash->base);
-
-  CARDANO_UNUSED(object);
-
-  return blake2b_hash;
-}
-
 const byte_t*
 cardano_blake2b_hash_get_data(const cardano_blake2b_hash_t* blake2b_hash)
 {

--- a/lib/src/crypto/ed25519_private_key.c
+++ b/lib/src/crypto/ed25519_private_key.c
@@ -678,21 +678,6 @@ cardano_ed25519_private_key_refcount(const cardano_ed25519_private_key_t* ed2551
   return cardano_object_refcount(&ed25519_private_key->base);
 }
 
-cardano_ed25519_private_key_t*
-cardano_ed25519_private_key_move(cardano_ed25519_private_key_t* ed25519_private_key)
-{
-  if (ed25519_private_key == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&ed25519_private_key->base);
-
-  CARDANO_UNUSED(object);
-
-  return ed25519_private_key;
-}
-
 cardano_error_t
 cardano_ed25519_private_key_sign(
   const cardano_ed25519_private_key_t* private_key,

--- a/lib/src/crypto/ed25519_public_key.c
+++ b/lib/src/crypto/ed25519_public_key.c
@@ -217,21 +217,6 @@ cardano_ed25519_public_key_refcount(const cardano_ed25519_public_key_t* ed25519_
   return cardano_object_refcount(&ed25519_public_key->base);
 }
 
-cardano_ed25519_public_key_t*
-cardano_ed25519_public_key_move(cardano_ed25519_public_key_t* ed25519_public_key)
-{
-  if (ed25519_public_key == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&ed25519_public_key->base);
-
-  CARDANO_UNUSED(object);
-
-  return ed25519_public_key;
-}
-
 bool
 cardano_ed25519_public_verify(
   const cardano_ed25519_public_key_t* public_key,

--- a/lib/src/crypto/ed25519_signature.c
+++ b/lib/src/crypto/ed25519_signature.c
@@ -216,21 +216,6 @@ cardano_ed25519_signature_refcount(const cardano_ed25519_signature_t* ed25519_si
   return cardano_object_refcount(&ed25519_signature->base);
 }
 
-cardano_ed25519_signature_t*
-cardano_ed25519_signature_move(cardano_ed25519_signature_t* ed25519_signature)
-{
-  if (ed25519_signature == NULL)
-  {
-    return NULL;
-  }
-
-  cardano_object_t* object = cardano_object_move(&ed25519_signature->base);
-
-  CARDANO_UNUSED(object);
-
-  return ed25519_signature;
-}
-
 const byte_t*
 cardano_ed25519_signature_get_data(const cardano_ed25519_signature_t* ed25519_signature)
 {

--- a/lib/src/endian.c
+++ b/lib/src/endian.c
@@ -65,7 +65,7 @@ reverse_memcpy(byte_t* dest, const size_t dest_size, const byte_t* src, const si
  * \return \c cardano_error_t Returns \c CARDANO_SUCCESS on success, member of \c cardano_error_t otherwise.
  */
 static cardano_error_t
-write(
+write_bytes(
   const byte_t* src,
   const size_t  src_size,
   byte_t*       dest,
@@ -103,7 +103,7 @@ write(
  * \return \c cardano_error_t Returns \c CARDANO_SUCCESS on success, member of \c cardano_error_t otherwise.
  */
 static cardano_error_t
-read(
+read_bytes(
   const byte_t* src,
   const size_t  src_size,
   byte_t*       dest,
@@ -148,7 +148,7 @@ cardano_is_big_endian(void)
 cardano_error_t
 cardano_write_uint16_le(const uint16_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -160,7 +160,7 @@ cardano_write_uint16_le(const uint16_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_uint32_le(const uint32_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -172,7 +172,7 @@ cardano_write_uint32_le(const uint32_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_uint64_le(const uint64_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -184,7 +184,7 @@ cardano_write_uint64_le(const uint64_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_int16_le(const int16_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -196,7 +196,7 @@ cardano_write_int16_le(const int16_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_int32_le(const int32_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -208,7 +208,7 @@ cardano_write_int32_le(const int32_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_int64_le(const int64_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -220,7 +220,7 @@ cardano_write_int64_le(const int64_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_float_le(const float value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -232,7 +232,7 @@ cardano_write_float_le(const float value, byte_t* buffer, const size_t size, con
 cardano_error_t
 cardano_write_double_le(const double value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -244,7 +244,7 @@ cardano_write_double_le(const double value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_uint16_be(const uint16_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -256,7 +256,7 @@ cardano_write_uint16_be(const uint16_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_uint32_be(const uint32_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -268,7 +268,7 @@ cardano_write_uint32_be(const uint32_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_uint64_be(const uint64_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -280,7 +280,7 @@ cardano_write_uint64_be(const uint64_t value, byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_write_int16_be(const int16_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -292,7 +292,7 @@ cardano_write_int16_be(const int16_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_int32_be(const int32_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -304,7 +304,7 @@ cardano_write_int32_be(const int32_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_int64_be(const int64_t value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -316,7 +316,7 @@ cardano_write_int64_be(const int64_t value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_write_float_be(const float value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -328,7 +328,7 @@ cardano_write_float_be(const float value, byte_t* buffer, const size_t size, con
 cardano_error_t
 cardano_write_double_be(const double value, byte_t* buffer, const size_t size, const size_t offset)
 {
-  return write(
+  return write_bytes(
     (const byte_t*)&value,
     sizeof(value),
     buffer,
@@ -340,7 +340,7 @@ cardano_write_double_be(const double value, byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_uint16_le(uint16_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -352,7 +352,7 @@ cardano_read_uint16_le(uint16_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_uint32_le(uint32_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -364,7 +364,7 @@ cardano_read_uint32_le(uint32_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_uint64_le(uint64_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -376,7 +376,7 @@ cardano_read_uint64_le(uint64_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_int16_le(int16_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -388,7 +388,7 @@ cardano_read_int16_le(int16_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_int32_le(int32_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -400,7 +400,7 @@ cardano_read_int32_le(int32_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_int64_le(int64_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -412,7 +412,7 @@ cardano_read_int64_le(int64_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_float_le(float* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -424,7 +424,7 @@ cardano_read_float_le(float* value, const byte_t* buffer, const size_t size, con
 cardano_error_t
 cardano_read_double_le(double* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -436,7 +436,7 @@ cardano_read_double_le(double* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_uint16_be(uint16_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -448,7 +448,7 @@ cardano_read_uint16_be(uint16_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_uint32_be(uint32_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -460,7 +460,7 @@ cardano_read_uint32_be(uint32_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_uint64_be(uint64_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -472,7 +472,7 @@ cardano_read_uint64_be(uint64_t* value, const byte_t* buffer, const size_t size,
 cardano_error_t
 cardano_read_int16_be(int16_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -484,7 +484,7 @@ cardano_read_int16_be(int16_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_int32_be(int32_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -496,7 +496,7 @@ cardano_read_int32_be(int32_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_int64_be(int64_t* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -508,7 +508,7 @@ cardano_read_int64_be(int64_t* value, const byte_t* buffer, const size_t size, c
 cardano_error_t
 cardano_read_float_be(float* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,
@@ -520,7 +520,7 @@ cardano_read_float_be(float* value, const byte_t* buffer, const size_t size, con
 cardano_error_t
 cardano_read_double_be(double* value, const byte_t* buffer, const size_t size, const size_t offset)
 {
-  return read(
+  return read_bytes(
     buffer,
     size,
     (byte_t*)value,

--- a/lib/src/object.c
+++ b/lib/src/object.c
@@ -100,22 +100,6 @@ cardano_object_refcount(const cardano_object_t* object)
   return object->ref_count;
 }
 
-cardano_object_t*
-cardano_object_move(cardano_object_t* object)
-{
-  if (object == NULL)
-  {
-    return NULL;
-  }
-
-  if (object->ref_count > 0U)
-  {
-    object->ref_count -= 1U;
-  }
-
-  return object;
-}
-
 void
 cardano_object_set_last_error(cardano_object_t* object, const char* message)
 {

--- a/lib/tests/address/address.cpp
+++ b/lib/tests/address/address.cpp
@@ -1580,24 +1580,6 @@ TEST(cardano_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_address_unref(&address);
 }
 
-TEST(cardano_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_address_t* address = NULL;
-  EXPECT_EQ(cardano_address_from_string(Cip19TestVectors::basePaymentKeyStakeKey.c_str(), Cip19TestVectors::basePaymentKeyStakeKey.size(), &address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_address_move(address), testing::Not((cardano_address_t*)nullptr));
-  size_t ref_count = cardano_address_refcount(address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(address, testing::Not((cardano_address_t*)nullptr));
-
-  // Cleanup
-  cardano_address_unref(&address);
-}
-
 TEST(cardano_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -1605,15 +1587,6 @@ TEST(cardano_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_address_t* address = cardano_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(address, (cardano_address_t*)nullptr);
 }
 
 TEST(cardano_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/address/base_address.cpp
+++ b/lib/tests/address/base_address.cpp
@@ -932,24 +932,6 @@ TEST(cardano_base_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_base_address_unref(&base_address);
 }
 
-TEST(cardano_base_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_base_address_t* base_address = NULL;
-  EXPECT_EQ(cardano_base_address_from_bech32(Cip19TestVectors::basePaymentKeyStakeKey.c_str(), Cip19TestVectors::basePaymentKeyStakeKey.size(), &base_address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_base_address_move(base_address), testing::Not((cardano_base_address_t*)nullptr));
-  size_t ref_count = cardano_base_address_refcount(base_address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(base_address, testing::Not((cardano_base_address_t*)nullptr));
-
-  // Cleanup
-  cardano_base_address_unref(&base_address);
-}
-
 TEST(cardano_base_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -957,15 +939,6 @@ TEST(cardano_base_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_base_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_base_address_t* base_address = cardano_base_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(base_address, (cardano_base_address_t*)nullptr);
 }
 
 TEST(cardano_base_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/address/byron_address.cpp
+++ b/lib/tests/address/byron_address.cpp
@@ -694,24 +694,6 @@ TEST(cardano_byron_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_byron_address_unref(&byron_address);
 }
 
-TEST(cardano_byron_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_byron_address_t* byron_address = NULL;
-  EXPECT_EQ(cardano_byron_address_from_base58(Cip19TestVectors::byronMainnetYoroi.c_str(), Cip19TestVectors::byronMainnetYoroi.size(), &byron_address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_byron_address_move(byron_address), testing::Not((cardano_byron_address_t*)nullptr));
-  size_t ref_count = cardano_byron_address_refcount(byron_address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(byron_address, testing::Not((cardano_byron_address_t*)nullptr));
-
-  // Cleanup
-  cardano_byron_address_unref(&byron_address);
-}
-
 TEST(cardano_byron_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -719,15 +701,6 @@ TEST(cardano_byron_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_byron_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_byron_address_t* byron_address = cardano_byron_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(byron_address, (cardano_byron_address_t*)nullptr);
 }
 
 TEST(cardano_byron_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/address/enterprise_address.cpp
+++ b/lib/tests/address/enterprise_address.cpp
@@ -709,24 +709,6 @@ TEST(cardano_enterprise_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_enterprise_address_unref(&enterprise_address);
 }
 
-TEST(cardano_enterprise_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_enterprise_address_t* enterprise_address = NULL;
-  EXPECT_EQ(cardano_enterprise_address_from_bech32(Cip19TestVectors::enterpriseKey.c_str(), Cip19TestVectors::enterpriseKey.size(), &enterprise_address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_enterprise_address_move(enterprise_address), testing::Not((cardano_enterprise_address_t*)nullptr));
-  size_t ref_count = cardano_enterprise_address_refcount(enterprise_address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(enterprise_address, testing::Not((cardano_enterprise_address_t*)nullptr));
-
-  // Cleanup
-  cardano_enterprise_address_unref(&enterprise_address);
-}
-
 TEST(cardano_enterprise_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -734,15 +716,6 @@ TEST(cardano_enterprise_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_enterprise_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_enterprise_address_t* enterprise_address = cardano_enterprise_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(enterprise_address, (cardano_enterprise_address_t*)nullptr);
 }
 
 TEST(cardano_enterprise_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/address/pointer_address.cpp
+++ b/lib/tests/address/pointer_address.cpp
@@ -773,24 +773,6 @@ TEST(cardano_pointer_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_pointer_address_unref(&pointer_address);
 }
 
-TEST(cardano_pointer_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_pointer_address_t* pointer_address = NULL;
-  EXPECT_EQ(cardano_pointer_address_from_bech32(Cip19TestVectors::pointerKey.c_str(), Cip19TestVectors::pointerKey.size(), &pointer_address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_pointer_address_move(pointer_address), testing::Not((cardano_pointer_address_t*)nullptr));
-  size_t ref_count = cardano_pointer_address_refcount(pointer_address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(pointer_address, testing::Not((cardano_pointer_address_t*)nullptr));
-
-  // Cleanup
-  cardano_pointer_address_unref(&pointer_address);
-}
-
 TEST(cardano_pointer_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -798,15 +780,6 @@ TEST(cardano_pointer_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_pointer_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_pointer_address_t* pointer_address = cardano_pointer_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(pointer_address, (cardano_pointer_address_t*)nullptr);
 }
 
 TEST(cardano_pointer_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/address/reward_address.cpp
+++ b/lib/tests/address/reward_address.cpp
@@ -714,24 +714,6 @@ TEST(cardano_reward_address_unref, freesTheObjectIfReferenceReachesZero)
   cardano_reward_address_unref(&reward_address);
 }
 
-TEST(cardano_reward_address_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_reward_address_t* reward_address = NULL;
-  EXPECT_EQ(cardano_reward_address_from_bech32(Cip19TestVectors::rewardKey.c_str(), Cip19TestVectors::rewardKey.size(), &reward_address), CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_reward_address_move(reward_address), testing::Not((cardano_reward_address_t*)nullptr));
-  size_t ref_count = cardano_reward_address_refcount(reward_address);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(reward_address, testing::Not((cardano_reward_address_t*)nullptr));
-
-  // Cleanup
-  cardano_reward_address_unref(&reward_address);
-}
-
 TEST(cardano_reward_address_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -739,15 +721,6 @@ TEST(cardano_reward_address_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_reward_address_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_reward_address_t* reward_address = cardano_reward_address_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(reward_address, (cardano_reward_address_t*)nullptr);
 }
 
 TEST(cardano_reward_address_get_last_error, returnsNullTerminatedMessage)

--- a/lib/tests/buffer/buffer.cpp
+++ b/lib/tests/buffer/buffer.cpp
@@ -232,35 +232,6 @@ TEST(cardano_buffer_unref, freesTheObjectIfReferenceReachesZero)
   EXPECT_EQ(buffer, (cardano_buffer_t*)nullptr);
 }
 
-TEST(cardano_buffer_move, returnsNullIfBufferIsNull)
-{
-  // Arrange
-  cardano_buffer_t* buffer = nullptr;
-
-  // Act
-  cardano_buffer_t* moved = cardano_buffer_move(buffer);
-
-  // Assert
-  EXPECT_EQ(moved, nullptr);
-}
-
-TEST(cardano_buffer_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_buffer_t* buffer = cardano_buffer_new(1);
-
-  // Act
-  EXPECT_THAT(cardano_buffer_move(buffer), testing::Not((cardano_buffer_t*)nullptr));
-  size_t ref_count = cardano_buffer_refcount(buffer);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(buffer, testing::Not((cardano_buffer_t*)nullptr));
-
-  // Cleanup
-  cardano_buffer_unref(&buffer);
-}
-
 TEST(cardano_buffer_get_data, returnsNullIfBufferIsNull)
 {
   // Arrange

--- a/lib/tests/cbor/cbor_reader.cpp
+++ b/lib/tests/cbor/cbor_reader.cpp
@@ -430,24 +430,6 @@ TEST(cardano_cbor_reader_unref, freesTheObjectIfReferenceReachesZero)
   cardano_cbor_reader_unref(&reader);
 }
 
-TEST(cardano_cbor_reader_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  const char*            cbor_hex = "81182a";
-  cardano_cbor_reader_t* reader   = cardano_cbor_reader_from_hex(cbor_hex, strlen(cbor_hex));
-
-  // Act
-  EXPECT_THAT(cardano_cbor_reader_move(reader), testing::Not((cardano_cbor_reader_t*)nullptr));
-  size_t ref_count = cardano_cbor_reader_refcount(reader);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(reader, testing::Not((cardano_cbor_reader_t*)nullptr));
-
-  // Cleanup
-  cardano_cbor_reader_unref(&reader);
-}
-
 TEST(cardano_cbor_reader_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -455,15 +437,6 @@ TEST(cardano_cbor_reader_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_cbor_reader_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_cbor_reader_t* reader = cardano_cbor_reader_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(reader, (cardano_cbor_reader_t*)nullptr);
 }
 
 TEST(cardano_cbor_reader_set_last_error, doesNothingWhenObjectIsNull)

--- a/lib/tests/cbor/cbor_writer.cpp
+++ b/lib/tests/cbor/cbor_writer.cpp
@@ -235,23 +235,6 @@ TEST(cardano_cbor_writer_unref, freesTheObjectIfReferenceReachesZero)
   cardano_cbor_writer_unref(&writer);
 }
 
-TEST(cardano_cbor_writer_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_cbor_writer_t* writer = cardano_cbor_writer_new();
-
-  // Act
-  EXPECT_THAT(cardano_cbor_writer_move(writer), testing::Not((cardano_cbor_writer_t*)nullptr));
-  size_t ref_count = cardano_cbor_writer_refcount(writer);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(writer, testing::Not((cardano_cbor_writer_t*)nullptr));
-
-  // Cleanup
-  cardano_cbor_writer_unref(&writer);
-}
-
 TEST(cardano_cbor_writer_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -259,15 +242,6 @@ TEST(cardano_cbor_writer_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_cbor_writer_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_cbor_writer_t* writer = cardano_cbor_writer_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(writer, (cardano_cbor_writer_t*)nullptr);
 }
 
 TEST(cardano_cbor_writer_tag, returnsNullIfGivenANullPtr)

--- a/lib/tests/collections/array.cpp
+++ b/lib/tests/collections/array.cpp
@@ -216,35 +216,6 @@ TEST(cardano_array_unref, freesTheObjectIfReferenceReachesZero)
   EXPECT_EQ(array, (cardano_array_t*)nullptr);
 }
 
-TEST(cardano_array_move, returnsNullIfArrayIsNull)
-{
-  // Arrange
-  cardano_array_t* array = nullptr;
-
-  // Act
-  cardano_array_t* moved = cardano_array_move(array);
-
-  // Assert
-  EXPECT_EQ(moved, nullptr);
-}
-
-TEST(cardano_array_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_array_t* array = cardano_array_new(1);
-
-  // Act
-  EXPECT_THAT(cardano_array_move(array), testing::Not((cardano_array_t*)nullptr));
-  size_t ref_count = cardano_array_refcount(array);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(array, testing::Not((cardano_array_t*)nullptr));
-
-  // Cleanup
-  cardano_array_unref(&array);
-}
-
 TEST(cardano_array_get_size, returnsZeroIfArrayIsNull)
 {
   // Arrange

--- a/lib/tests/collections/set.cpp
+++ b/lib/tests/collections/set.cpp
@@ -382,35 +382,6 @@ TEST(cardano_set_unref, freesTheObjectIfReferenceReachesZero)
   EXPECT_EQ(set, (cardano_set_t*)nullptr);
 }
 
-TEST(cardano_set_move, returnsNullIfSetIsNull)
-{
-  // Arrange
-  cardano_set_t* set = nullptr;
-
-  // Act
-  cardano_set_t* moved = cardano_set_move(set);
-
-  // Assert
-  EXPECT_EQ(moved, nullptr);
-}
-
-TEST(cardano_set_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_set_t* set = cardano_set_new(compare, hash);
-
-  // Act
-  EXPECT_THAT(cardano_set_move(set), testing::Not((cardano_set_t*)nullptr));
-  size_t ref_count = cardano_set_refcount(set);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(set, testing::Not((cardano_set_t*)nullptr));
-
-  // Cleanup
-  cardano_set_unref(&set);
-}
-
 TEST(cardano_set_get_size, returnsZeroIfSetIsNull)
 {
   // Arrange

--- a/lib/tests/common/credential.cpp
+++ b/lib/tests/common/credential.cpp
@@ -821,30 +821,6 @@ TEST(cardano_credential_unref, freesTheObjectIfReferenceReachesZero)
   cardano_credential_unref(&credential);
 }
 
-TEST(cardano_credential_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_credential_t* credential = nullptr;
-  cardano_error_t       error      = cardano_credential_from_hash_hex(
-    KEY_HASH_HEX,
-    strlen(KEY_HASH_HEX),
-    CARDANO_CREDENTIAL_TYPE_KEY_HASH,
-    &credential);
-
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_credential_move(credential), testing::Not((cardano_credential_t*)nullptr));
-  size_t ref_count = cardano_credential_refcount(credential);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(credential, testing::Not((cardano_credential_t*)nullptr));
-
-  // Cleanup
-  cardano_credential_unref(&credential);
-}
-
 TEST(cardano_credential_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -852,15 +828,6 @@ TEST(cardano_credential_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_credential_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_credential_t* credential = cardano_credential_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(credential, (cardano_credential_t*)nullptr);
 }
 
 TEST(cardano_credential_set_last_error, doesNothingWhenObjectIsNull)

--- a/lib/tests/crypto/bip32_private_key.cpp
+++ b/lib/tests/crypto/bip32_private_key.cpp
@@ -175,25 +175,6 @@ TEST(cardano_bip32_private_key_unref, freesTheObjectIfReferenceReachesZero)
   cardano_bip32_private_key_unref(&private_key);
 }
 
-TEST(cardano_bip32_private_key_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_bip32_private_key_t* private_key = nullptr;
-  cardano_error_t              error       = cardano_bip32_private_key_from_bytes(BIP32_PRIVATE_KEY, BIP32_PRIVATE_KEY_SIZE, &private_key);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_bip32_private_key_move(private_key), testing::Not((cardano_bip32_private_key_t*)nullptr));
-  size_t ref_count = cardano_bip32_private_key_refcount(private_key);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(private_key, testing::Not((cardano_bip32_private_key_t*)nullptr));
-
-  // Cleanup
-  cardano_bip32_private_key_unref(&private_key);
-}
-
 TEST(cardano_bip32_private_key_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -201,15 +182,6 @@ TEST(cardano_bip32_private_key_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_bip32_private_key_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_bip32_private_key_t* private_key = cardano_bip32_private_key_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(private_key, (cardano_bip32_private_key_t*)nullptr);
 }
 
 TEST(cardano_bip32_private_key_from_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/crypto/bip32_public_key.cpp
+++ b/lib/tests/crypto/bip32_public_key.cpp
@@ -150,25 +150,6 @@ TEST(cardano_bip32_public_key_unref, freesTheObjectIfReferenceReachesZero)
   cardano_bip32_public_key_unref(&public_key);
 }
 
-TEST(cardano_bip32_public_key_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_bip32_public_key_t* public_key = nullptr;
-  cardano_error_t             error      = cardano_bip32_public_key_from_bytes(BIP32_PUBLIC_KEY, BIP32_PUBLIC_KEY_SIZE, &public_key);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_bip32_public_key_move(public_key), testing::Not((cardano_bip32_public_key_t*)nullptr));
-  size_t ref_count = cardano_bip32_public_key_refcount(public_key);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(public_key, testing::Not((cardano_bip32_public_key_t*)nullptr));
-
-  // Cleanup
-  cardano_bip32_public_key_unref(&public_key);
-}
-
 TEST(cardano_bip32_public_key_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -176,15 +157,6 @@ TEST(cardano_bip32_public_key_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_bip32_public_key_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_bip32_public_key_t* public_key = cardano_bip32_public_key_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(public_key, (cardano_bip32_public_key_t*)nullptr);
 }
 
 TEST(cardano_bip32_public_key_from_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/crypto/blake2b_hash.cpp
+++ b/lib/tests/crypto/blake2b_hash.cpp
@@ -232,25 +232,6 @@ TEST(cardano_blake2b_hash_unref, freesTheObjectIfReferenceReachesZero)
   cardano_blake2b_hash_unref(&hash);
 }
 
-TEST(cardano_blake2b_hash_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_blake2b_hash_t* hash  = nullptr;
-  cardano_error_t         error = cardano_blake2b_compute_hash((const byte_t*)"data", 4, CARDANO_BLAKE2B_HASH_SIZE_512, &hash);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_blake2b_hash_move(hash), testing::Not((cardano_blake2b_hash_t*)nullptr));
-  size_t ref_count = cardano_blake2b_hash_refcount(hash);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(hash, testing::Not((cardano_blake2b_hash_t*)nullptr));
-
-  // Cleanup
-  cardano_blake2b_hash_unref(&hash);
-}
-
 TEST(cardano_blake2b_hash_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -258,15 +239,6 @@ TEST(cardano_blake2b_hash_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_blake2b_hash_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_blake2b_hash_t* hash = cardano_blake2b_hash_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(hash, (cardano_blake2b_hash_t*)nullptr);
 }
 
 TEST(cardano_blake2b_hash_from_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/crypto/ed25519_private_key.cpp
+++ b/lib/tests/crypto/ed25519_private_key.cpp
@@ -170,25 +170,6 @@ TEST(cardano_ed25519_private_key_unref, freesTheObjectIfReferenceReachesZero)
   cardano_ed25519_private_key_unref(&private_key);
 }
 
-TEST(cardano_ed25519_private_key_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_ed25519_private_key_t* private_key = nullptr;
-  cardano_error_t                error       = cardano_ed25519_private_key_from_normal_bytes(PRIVATE_KEY, PRIVATE_KEY_SIZE, &private_key);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_ed25519_private_key_move(private_key), testing::Not((cardano_ed25519_private_key_t*)nullptr));
-  size_t ref_count = cardano_ed25519_private_key_refcount(private_key);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(private_key, testing::Not((cardano_ed25519_private_key_t*)nullptr));
-
-  // Cleanup
-  cardano_ed25519_private_key_unref(&private_key);
-}
-
 TEST(cardano_ed25519_private_key_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -196,15 +177,6 @@ TEST(cardano_ed25519_private_key_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_ed25519_private_key_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_ed25519_private_key_t* private_key = cardano_ed25519_private_key_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(private_key, (cardano_ed25519_private_key_t*)nullptr);
 }
 
 TEST(cardano_ed25519_private_key_from_normal_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/crypto/ed25519_public_key.cpp
+++ b/lib/tests/crypto/ed25519_public_key.cpp
@@ -137,25 +137,6 @@ TEST(cardano_ed25519_public_key_unref, freesTheObjectIfReferenceReachesZero)
   cardano_ed25519_public_key_unref(&public_key);
 }
 
-TEST(cardano_ed25519_public_key_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_ed25519_public_key_t* public_key = nullptr;
-  cardano_error_t               error      = cardano_ed25519_public_key_from_bytes(PUBLIC_KEY, PUBLIC_KEY_SIZE, &public_key);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_ed25519_public_key_move(public_key), testing::Not((cardano_ed25519_public_key_t*)nullptr));
-  size_t ref_count = cardano_ed25519_public_key_refcount(public_key);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(public_key, testing::Not((cardano_ed25519_public_key_t*)nullptr));
-
-  // Cleanup
-  cardano_ed25519_public_key_unref(&public_key);
-}
-
 TEST(cardano_ed25519_public_key_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -163,15 +144,6 @@ TEST(cardano_ed25519_public_key_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_ed25519_public_key_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_ed25519_public_key_t* public_key = cardano_ed25519_public_key_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(public_key, (cardano_ed25519_public_key_t*)nullptr);
 }
 
 TEST(cardano_ed25519_public_key_from_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/crypto/ed25519_signature.cpp
+++ b/lib/tests/crypto/ed25519_signature.cpp
@@ -135,25 +135,6 @@ TEST(cardano_ed25519_signature_unref, freesTheObjectIfReferenceReachesZero)
   cardano_ed25519_signature_unref(&signature);
 }
 
-TEST(cardano_ed25519_signature_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_ed25519_signature_t* signature = nullptr;
-  cardano_error_t              error     = cardano_ed25519_signature_from_bytes(SIGNATURE_BYTES, SIGNATURE_SIZE, &signature);
-  ASSERT_EQ(error, CARDANO_SUCCESS);
-
-  // Act
-  EXPECT_THAT(cardano_ed25519_signature_move(signature), testing::Not((cardano_ed25519_signature_t*)nullptr));
-  size_t ref_count = cardano_ed25519_signature_refcount(signature);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(signature, testing::Not((cardano_ed25519_signature_t*)nullptr));
-
-  // Cleanup
-  cardano_ed25519_signature_unref(&signature);
-}
-
 TEST(cardano_ed25519_signature_refcount, returnsZeroIfGivenANullPtr)
 {
   // Act
@@ -161,15 +142,6 @@ TEST(cardano_ed25519_signature_refcount, returnsZeroIfGivenANullPtr)
 
   // Assert
   EXPECT_EQ(ref_count, 0);
-}
-
-TEST(cardano_ed25519_signature_move, returnsNullIfGivenANullPtr)
-{
-  // Act
-  cardano_ed25519_signature_t* signature = cardano_ed25519_signature_move(nullptr);
-
-  // Assert
-  EXPECT_EQ(signature, (cardano_ed25519_signature_t*)nullptr);
 }
 
 TEST(cardano_ed25519_signature_from_bytes, returnsNullIfGivenANullPtr)

--- a/lib/tests/object.cpp
+++ b/lib/tests/object.cpp
@@ -188,35 +188,6 @@ TEST(cardano_object_unref, freesTheObjectIfReferenceReachesZero)
   EXPECT_EQ(object, (cardano_object_t*)nullptr);
 }
 
-TEST(cardano_object_move, returnsNullIfObjectIsNull)
-{
-  // Arrange
-  cardano_object_t* object = nullptr;
-
-  // Act
-  cardano_object_t* moved = cardano_object_move(object);
-
-  // Assert
-  EXPECT_EQ(moved, nullptr);
-}
-
-TEST(cardano_object_move, decreasesTheReferenceCountWithoutDeletingTheObject)
-{
-  // Arrange
-  cardano_object_t* object = cardano_object_new(_cardano_free);
-
-  // Act
-  EXPECT_THAT(cardano_object_move(object), testing::Not((cardano_object_t*)nullptr));
-  size_t ref_count = cardano_object_refcount(object);
-
-  // Assert
-  EXPECT_EQ(ref_count, 0);
-  EXPECT_THAT(object, testing::Not((cardano_object_t*)nullptr));
-
-  // Cleanup
-  cardano_object_unref(&object);
-}
-
 TEST(cardano_object_refcount, returnsZeroIfObjectIsNull)
 {
   // Arrange


### PR DESCRIPTION
## Description

the move semantics seemed like a good idea as it reduce boilerplate in some cases, but it is too error prone/dangerous as it can lead to memory leaks when not used correctly, so we just decide to remove this feature.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [x] I have added tests
    - [x] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [x] Are there any breaking changes?
    - [x] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?