### PR TITLE
fix: make plutus list serialize according to plutus core rules

### DIFF
--- a/lib/src/plutus_data/plutus_data.c
+++ b/lib/src/plutus_data/plutus_data.c
@@ -420,6 +420,8 @@ cardano_plutus_data_from_cbor(cardano_cbor_reader_t* reader, cardano_plutus_data
             return result;
           }
 
+          // TODO: Plutus integers are unbounded, but we are using int64_t for now. Implement a proper
+          //       bigint type for plutus integers (cardano_bigint_t?).
           const int64_t integer = buffer_to_le_int(bytes);
 
           cardano_buffer_unref(&bytes);
@@ -495,6 +497,8 @@ cardano_plutus_data_from_cbor(cardano_cbor_reader_t* reader, cardano_plutus_data
     {
       int64_t integer = 0;
 
+      // TODO: same here we need to be able to read up to unsigned 64-bit integers. Implement a proper
+      //       bigint type for plutus integers (cardano_bigint_t?).
       result = cardano_cbor_reader_read_int(reader, &integer);
 
       if (result != CARDANO_SUCCESS)

--- a/lib/tests/plutus_data/constr_plutus_data.cpp
+++ b/lib/tests/plutus_data/constr_plutus_data.cpp
@@ -123,14 +123,14 @@ TEST(cardano_constr_plutus_data_to_cbor, canSerializeAnEmptyConstrPlutusData)
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
   const size_t hex_size = cardano_cbor_writer_get_hex_size(writer);
-  EXPECT_EQ(hex_size, 9);
+  EXPECT_EQ(hex_size, 7);
 
   char* actual_cbor = (char*)malloc(hex_size);
 
   error = cardano_cbor_writer_encode_hex(writer, actual_cbor, hex_size);
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
-  EXPECT_STREQ(actual_cbor, "d8799fff");
+  EXPECT_STREQ(actual_cbor, "d87980");
 
   // Cleanup
   cardano_constr_plutus_data_unref(&constr_plutus_data);

--- a/lib/tests/plutus_data/plutus_data.cpp
+++ b/lib/tests/plutus_data/plutus_data.cpp
@@ -1245,7 +1245,7 @@ TEST(cardano_plutus_data_to_cbor, canDeserializeAndReserializeCbor)
 {
   // Arrange
   cardano_plutus_data_t* plutus_data = nullptr;
-  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex("820102", strlen("820102"));
+  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex("9f0102ff", strlen("9f0102ff"));
   cardano_cbor_writer_t* writer      = cardano_cbor_writer_new();
 
   cardano_error_t error = cardano_plutus_data_from_cbor(reader, &plutus_data);
@@ -1255,14 +1255,14 @@ TEST(cardano_plutus_data_to_cbor, canDeserializeAndReserializeCbor)
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
   const size_t hex_size = cardano_cbor_writer_get_hex_size(writer);
-  EXPECT_EQ(hex_size, strlen("820102") + 1);
+  EXPECT_EQ(hex_size, strlen("9f0102ff") + 1);
 
   char* actual_cbor = (char*)malloc(hex_size);
 
   error = cardano_cbor_writer_encode_hex(writer, actual_cbor, hex_size);
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
-  EXPECT_STREQ(actual_cbor, "820102");
+  EXPECT_STREQ(actual_cbor, "9f0102ff");
 
   // Cleanup
   cardano_plutus_data_unref(&plutus_data);

--- a/lib/tests/plutus_data/plutus_list.cpp
+++ b/lib/tests/plutus_data/plutus_list.cpp
@@ -116,14 +116,14 @@ TEST(cardano_plutus_list_to_cbor, canSerializeAnEmptyPlutusList)
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
   const size_t hex_size = cardano_cbor_writer_get_hex_size(writer);
-  EXPECT_EQ(hex_size, 5);
+  EXPECT_EQ(hex_size, 3);
 
   char* actual_cbor = (char*)malloc(hex_size);
 
   error = cardano_cbor_writer_encode_hex(writer, actual_cbor, hex_size);
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
-  EXPECT_STREQ(actual_cbor, "9fff");
+  EXPECT_STREQ(actual_cbor, "80");
 
   // Cleanup
   cardano_plutus_list_unref(&plutus_list);
@@ -281,7 +281,7 @@ TEST(cardano_plutus_list_to_cbor, canDeserializeAndReserializeCbor)
 {
   // Arrange
   cardano_plutus_list_t* plutus_list = nullptr;
-  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex("820102", strlen("820102"));
+  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex("9f0102ff", strlen("9f0102ff"));
   cardano_cbor_writer_t* writer      = cardano_cbor_writer_new();
 
   cardano_error_t error = cardano_plutus_list_from_cbor(reader, &plutus_list);
@@ -291,14 +291,14 @@ TEST(cardano_plutus_list_to_cbor, canDeserializeAndReserializeCbor)
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
   const size_t hex_size = cardano_cbor_writer_get_hex_size(writer);
-  EXPECT_EQ(hex_size, strlen("820102") + 1);
+  EXPECT_EQ(hex_size, strlen("9f0102ff") + 1);
 
   char* actual_cbor = (char*)malloc(hex_size);
 
   error = cardano_cbor_writer_encode_hex(writer, actual_cbor, hex_size);
   EXPECT_EQ(error, CARDANO_SUCCESS);
 
-  EXPECT_STREQ(actual_cbor, "820102");
+  EXPECT_STREQ(actual_cbor, "9f0102ff");
 
   // Cleanup
   cardano_plutus_list_unref(&plutus_list);


### PR DESCRIPTION
## Description

As seen here https://github.com/input-output-hk/cardano-js-sdk/issues/1318 our current plutus list serliazation logic is incorrect

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [x] I have added tests
    - [ ] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?