### PR TITLE
feat: CBOR reader and writer can now encode/decode bigints properly

### DIFF
--- a/doc/src/sections/api/cbor/cbor_reader.rst
+++ b/doc/src/sections/api/cbor/cbor_reader.rst
@@ -37,6 +37,10 @@ CBOR Reader
 
 ------------
 
+.. doxygenfunction:: cardano_cbor_reader_read_bigint
+
+------------
+
 .. doxygenfunction:: cardano_cbor_reader_read_boolean
 
 ------------

--- a/doc/src/sections/api/cbor/cbor_writer.rst
+++ b/doc/src/sections/api/cbor/cbor_writer.rst
@@ -53,7 +53,7 @@ CBOR Writer
 
 ------------
 
-.. doxygenfunction:: cardano_cbor_writer_write_big_integer
+.. doxygenfunction:: cardano_cbor_writer_write_bigint
 
 ------------
 
@@ -61,7 +61,7 @@ CBOR Writer
 
 ------------
 
-.. doxygenfunction:: cardano_cbor_writer_write_byte_string
+.. doxygenfunction:: cardano_cbor_writer_write_bytestring
 
 ------------
 
@@ -97,7 +97,7 @@ CBOR Writer
 
 ------------
 
-.. doxygenfunction:: cardano_cbor_writer_write_text_string
+.. doxygenfunction:: cardano_cbor_writer_write_textstring
 
 ------------
 

--- a/lib/include/cardano/cbor/cbor_reader.h
+++ b/lib/include/cardano/cbor/cbor_reader.h
@@ -28,6 +28,7 @@
 #include <cardano/cbor/cbor_reader_state.h>
 #include <cardano/cbor/cbor_simple_value.h>
 #include <cardano/cbor/cbor_tag.h>
+#include <cardano/common/bigint.h>
 #include <cardano/error.h>
 #include <cardano/export.h>
 #include <cardano/typedefs.h>
@@ -536,6 +537,47 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_reader_read_int(cardano_cbor_reader_
  */
 CARDANO_NODISCARD
 CARDANO_EXPORT cardano_error_t cardano_cbor_reader_read_uint(cardano_cbor_reader_t* reader, uint64_t* value);
+
+/**
+ * \brief Decodes and reads a big integer (bignum) from CBOR format.
+ *
+ * This function reads and decodes a bignum from a provided CBOR reader, following the
+ * encoding format specified in RFC 7049, section 2.4.2. Bignums are used to represent
+ * integers that are too large to be represented directly in the available integer types
+ * of CBOR. The function interprets the appropriate tag (2 for unsigned bignum) and decodes
+ * the integer value, ensuring its correct representation as a bignum in the resulting bigint object.
+ *
+ * \param[in] reader The \ref cardano_cbor_reader_t instance from which the bignum will be read.
+ * \param[out] bigint A pointer to a pointer that will be set to the address of the newly created \ref cardano_bigint_t object
+ *                    representing the decoded big integer value. The caller is responsible for managing the memory of this object.
+ *
+ * \return Returns \ref CARDANO_SUCCESS if the bignum value was successfully decoded and read from the
+ *         CBOR stream. If the operation encounters an error, such as invalid parameters or issues with
+ *         reading from the stream, an appropriate error code is returned indicating the reason for the failure.
+ *         Consult the \ref cardano_error_t documentation for details on possible error codes and their meanings.
+ *
+ * Example usage:
+ * \code{.c}
+ * cardano_cbor_reader_t* reader = cardano_cbor_reader_new(cbor_data, cbor_data_size);
+ * if (reader)
+ * {
+ *   cardano_bigint_t* bigint = NULL;
+ *   cardano_error_t result = cardano_cbor_reader_read_bigint(reader, &bigint);
+ *
+ *   if (result == CARDANO_SUCCESS)
+ *   {
+ *     // Successfully read bignum from the reader
+ *     // Use the bigint
+ *   }
+ *
+ *   // Clean up
+ *   cardano_bigint_unref(&bigint);
+ *   cardano_cbor_reader_unref(&reader);
+ * }
+ * \endcode
+ */
+CARDANO_NODISCARD
+CARDANO_EXPORT cardano_error_t cardano_cbor_reader_read_bigint(cardano_cbor_reader_t* reader, cardano_bigint_t** bigint);
 
 /**
  * \brief Reads the next data item as a double-precision floating point number (major type 7).

--- a/lib/include/cardano/cbor/cbor_writer.h
+++ b/lib/include/cardano/cbor/cbor_writer.h
@@ -26,6 +26,7 @@
 
 #include <cardano/buffer.h>
 #include <cardano/cbor/cbor_tag.h>
+#include <cardano/common/bigint.h>
 #include <cardano/error.h>
 #include <cardano/export.h>
 #include <cardano/typedefs.h>
@@ -159,20 +160,18 @@ CARDANO_NODISCARD
 CARDANO_EXPORT size_t cardano_cbor_writer_refcount(const cardano_cbor_writer_t* cbor_writer);
 
 /**
- * \brief Encodes and writes an unsigned integer value as a tagged big number (bignum) in CBOR format.
+ * \brief Encodes and writes a big integer (bignum) in CBOR format.
  *
- * This function writes a provided unsigned integer value as a bignum, following the
+ * This function writes a provided big integer value as a bignum, following the
  * encoding format specified in RFC 7049, section 2.4.2. Bignums are used to represent
  * integers that are too large to be represented directly in the available integer types
  * of CBOR. The function applies the appropriate tag (2 for unsigned bignum) before encoding
  * the integer value, ensuring its correct interpretation as a bignum in the resulting CBOR data.
  *
  * \param[in] writer The \ref cardano_cbor_writer_t instance to which the bignum will be written.
- * \param[in] value The unsigned integer value to be encoded as a bignum. The value is treated
- *                  as an arbitrary precision integer, although it is passed as a \c uint64_t
- *                  for practical purposes.
+ * \param[in] bigint The \ref cardano_bigint_t object representing the big integer value to be encoded as a bignum.
  *
- * \return Returns \ref CARDANO_SUCCESS if the boolean value was successfully encoded and written to the
+ * \return Returns \ref CARDANO_SUCCESS if the bignum value was successfully encoded and written to the
  *         CBOR stream. If the operation encounters an error, such as invalid parameters or issues with
  *         writing to the stream, an appropriate error code is returned indicating the reason for the failure.
  *         Consult the \ref cardano_error_t documentation for details on possible error codes and their meanings.
@@ -180,22 +179,24 @@ CARDANO_EXPORT size_t cardano_cbor_writer_refcount(const cardano_cbor_writer_t* 
  * Example usage:
  * \code{.c}
  * cardano_cbor_writer_t* writer = cardano_cbor_writer_new();
+ *
  * if (writer)
  * {
- *   uint64_t bigNumValue = UINT64_MAX; // Example large value to encode as bignum
- *   cardano_error_t result = cardano_cbor_writer_write_big_integer(writer, bigNumValue);
+ *   // Example large value to encode as bignum
+ *   cardano_bigint_t* bigint = NULL;
+ *   cardano_bigint_from_string("123456789123456789123456789", strln("123456789123456789123456789"), 10, &bigint);
  *
- *   if (result == CARDANO_SUCCESS)
- *   {
- *     // Successfully written bigNumValue as a bignum to the writer
- *   }
+ *   cardano_error_t result = cardano_cbor_writer_write_bigint(writer, bigint);
  *
+ *   ...
+ *
+ *   cardano_bigint_unref(&bigint);
  *   cardano_cbor_writer_unref(&writer);
  * }
  * \endcode
  */
 CARDANO_NODISCARD
-CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_big_integer(cardano_cbor_writer_t* writer, uint64_t value);
+CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_bigint(cardano_cbor_writer_t* writer, const cardano_bigint_t* bigint);
 
 /**
  * \brief Encodes and writes a boolean value in CBOR format as per RFC 7049, section 2.3.
@@ -265,7 +266,7 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_bool(cardano_cbor_write
  * byte_t data[] = {0xde, 0xad, 0xbe, 0xef}; // Example binary data
  * size_t data_size = sizeof(data);
  *
- * cardano_error_t result = cardano_cbor_writer_write_byte_string(writer, data, data_size);
+ * cardano_error_t result = cardano_cbor_writer_write_bytestring(writer, data, data_size);
  *
  * if (result == CARDANO_SUCCESS)
  * {
@@ -280,7 +281,7 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_bool(cardano_cbor_write
  * \endcode
  */
 CARDANO_NODISCARD
-CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_byte_string(cardano_cbor_writer_t* writer, const byte_t* data, size_t size);
+CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_bytestring(cardano_cbor_writer_t* writer, const byte_t* data, size_t size);
 
 /**
  * \brief Encodes and writes a UTF-8 encoded text string as a CBOR text string (major type 3).
@@ -311,7 +312,7 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_byte_string(cardano_cbo
  * {
  *   const char* text = "Hello, CBOR!";
  *   size_t text_length = strlen(text);
- *   cardano_error_t result = cardano_cbor_writer_write_text_string(writer, text, text_length);
+ *   cardano_error_t result = cardano_cbor_writer_write_textstring(writer, text, text_length);
  *
  *   if (result == CARDANO_SUCCESS)
  *   {
@@ -323,7 +324,7 @@ CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_byte_string(cardano_cbo
  * \endcode
  */
 CARDANO_NODISCARD
-CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_text_string(cardano_cbor_writer_t* writer, const char* data, size_t size);
+CARDANO_EXPORT cardano_error_t cardano_cbor_writer_write_textstring(cardano_cbor_writer_t* writer, const char* data, size_t size);
 
 /**
  * \brief Writes a buffer containing a pre-encoded CBOR data item into a CBOR stream.

--- a/lib/src/address/internals/byron_addr_pack.c
+++ b/lib/src/address/internals/byron_addr_pack.c
@@ -64,7 +64,7 @@ _cardano_byron_address_initialize(cardano_cbor_writer_t* writer, const cardano_a
     return result; // LCOV_EXCL_LINE
   }
 
-  result = cardano_cbor_writer_write_byte_string(writer, address->byron_content->root, sizeof(address->byron_content->root));
+  result = cardano_cbor_writer_write_bytestring(writer, address->byron_content->root, sizeof(address->byron_content->root));
 
   if (result != CARDANO_SUCCESS)
   {
@@ -120,7 +120,7 @@ _cardano_byron_address_encode_magic(cardano_cbor_writer_t* writer, const cardano
     result = cardano_cbor_writer_write_unsigned_int(writer, 2);
     if (result == CARDANO_SUCCESS)
     {
-      result = cardano_cbor_writer_write_byte_string(writer, magic_data, magic_size);
+      result = cardano_cbor_writer_write_bytestring(writer, magic_data, magic_size);
     }
     _cardano_free(magic_data);
   }
@@ -137,7 +137,7 @@ _cardano_byron_address_encode_derivation_path(cardano_cbor_writer_t* writer, con
   assert(address != NULL);
 
   cardano_cbor_writer_t* attributes_writer = cardano_cbor_writer_new();
-  cardano_error_t        result            = cardano_cbor_writer_write_byte_string(
+  cardano_error_t        result            = cardano_cbor_writer_write_bytestring(
     attributes_writer,
     address->byron_content->attributes.derivation_path,
     address->byron_content->attributes.derivation_path_size);
@@ -161,7 +161,7 @@ _cardano_byron_address_encode_derivation_path(cardano_cbor_writer_t* writer, con
 
     if (result == CARDANO_SUCCESS)
     {
-      result = cardano_cbor_writer_write_byte_string(writer, attributes_data, attributes_size);
+      result = cardano_cbor_writer_write_bytestring(writer, attributes_data, attributes_size);
     }
     _cardano_free(attributes_data);
   }
@@ -241,7 +241,7 @@ _cardano_byron_address_write_final_structure(
     return result; // LCOV_EXCL_LINE
   }
 
-  result = cardano_cbor_writer_write_byte_string(writer, encoded_data, encoded_size);
+  result = cardano_cbor_writer_write_bytestring(writer, encoded_data, encoded_size);
 
   if (result != CARDANO_SUCCESS)
   {

--- a/lib/src/cbor/cbor_reader/cbor_reader.c
+++ b/lib/src/cbor/cbor_reader/cbor_reader.c
@@ -466,6 +466,12 @@ cardano_cbor_reader_read_uint(cardano_cbor_reader_t* reader, uint64_t* value)
 }
 
 cardano_error_t
+cardano_cbor_reader_read_bigint(cardano_cbor_reader_t* reader, cardano_bigint_t** bigint)
+{
+  return _cardano_reader_read_bigint(reader, bigint);
+}
+
+cardano_error_t
 cardano_cbor_reader_read_double(cardano_cbor_reader_t* reader, double* value)
 {
   return _cbor_reader_read_double(reader, value);

--- a/lib/src/cbor/cbor_reader/cbor_reader_numeric.h
+++ b/lib/src/cbor/cbor_reader/cbor_reader_numeric.h
@@ -118,4 +118,25 @@ _cbor_reader_read_int(cardano_cbor_reader_t* reader, int64_t* value);
 cardano_error_t
 _cbor_reader_read_uint(cardano_cbor_reader_t* reader, uint64_t* value);
 
+/**
+ * \brief Decodes and reads a big integer (bignum) from CBOR format.
+ *
+ * This function reads and decodes a bignum from a provided CBOR reader, following the
+ * encoding format specified in RFC 7049, section 2.4.2. Bignums are used to represent
+ * integers that are too large to be represented directly in the available integer types
+ * of CBOR. The function interprets the appropriate tag (2 for unsigned bignum) and decodes
+ * the integer value, ensuring its correct representation as a bignum in the resulting bigint object.
+ *
+ * \param[in] reader The \ref cardano_cbor_reader_t instance from which the bignum will be read.
+ * \param[out] bigint A pointer to a pointer that will be set to the address of the newly created \ref cardano_bigint_t object
+ *                    representing the decoded big integer value. The caller is responsible for managing the memory of this object.
+ *
+ * \return Returns \ref CARDANO_SUCCESS if the bignum value was successfully decoded and read from the
+ *         CBOR stream. If the operation encounters an error, such as invalid parameters or issues with
+ *         reading from the stream, an appropriate error code is returned indicating the reason for the failure.
+ *         Consult the \ref cardano_error_t documentation for details on possible error codes and their meanings.
+ */
+cardano_error_t
+_cardano_reader_read_bigint(cardano_cbor_reader_t* reader, cardano_bigint_t** bigint);
+
 #endif // CARDANO_CBOR_READER_INTERNAL_NUMERIC_H

--- a/lib/src/common/anchor.c
+++ b/lib/src/common/anchor.c
@@ -340,14 +340,14 @@ cardano_anchor_to_cbor(
     return write_start_array_result; /* LCOV_EXCL_LINE */
   }
 
-  cardano_error_t write_url_result = cardano_cbor_writer_write_text_string(writer, anchor->url, cardano_safe_strlen(anchor->url, sizeof(anchor->url)));
+  cardano_error_t write_url_result = cardano_cbor_writer_write_textstring(writer, anchor->url, cardano_safe_strlen(anchor->url, sizeof(anchor->url)));
 
   if (write_url_result != CARDANO_SUCCESS)
   {
     return write_url_result; /* LCOV_EXCL_LINE */
   }
 
-  cardano_error_t write_bytes_result = cardano_cbor_writer_write_byte_string(writer, anchor->hash_bytes, sizeof(anchor->hash_bytes));
+  cardano_error_t write_bytes_result = cardano_cbor_writer_write_bytestring(writer, anchor->hash_bytes, sizeof(anchor->hash_bytes));
 
   if (write_bytes_result != CARDANO_SUCCESS)
   {

--- a/lib/src/common/credential.c
+++ b/lib/src/common/credential.c
@@ -320,7 +320,7 @@ cardano_credential_to_cbor(
     return write_uint_result; /* LCOV_EXCL_LINE */
   }
 
-  cardano_error_t write_bytes_result = cardano_cbor_writer_write_byte_string(writer, credential->hash_bytes, sizeof(credential->hash_bytes));
+  cardano_error_t write_bytes_result = cardano_cbor_writer_write_bytestring(writer, credential->hash_bytes, sizeof(credential->hash_bytes));
 
   if (write_bytes_result != CARDANO_SUCCESS)
   {

--- a/lib/src/common/datum.c
+++ b/lib/src/common/datum.c
@@ -394,7 +394,7 @@ cardano_datum_to_cbor(
   {
     case CARDANO_DATUM_TYPE_DATA_HASH:
     {
-      cardano_error_t write_bytes_result = cardano_cbor_writer_write_byte_string(writer, datum->hash_bytes, sizeof(datum->hash_bytes));
+      cardano_error_t write_bytes_result = cardano_cbor_writer_write_bytestring(writer, datum->hash_bytes, sizeof(datum->hash_bytes));
 
       if (write_bytes_result != CARDANO_SUCCESS)
       {

--- a/lib/src/common/governance_action_id.c
+++ b/lib/src/common/governance_action_id.c
@@ -315,7 +315,7 @@ cardano_governance_action_id_to_cbor(
     return write_start_array_result; /* LCOV_EXCL_LINE */
   }
 
-  cardano_error_t write_bytes_result = cardano_cbor_writer_write_byte_string(writer, governance_action_id->hash_bytes, sizeof(governance_action_id->hash_bytes));
+  cardano_error_t write_bytes_result = cardano_cbor_writer_write_bytestring(writer, governance_action_id->hash_bytes, sizeof(governance_action_id->hash_bytes));
 
   if (write_bytes_result != CARDANO_SUCCESS)
   {

--- a/lib/src/crypto/blake2b_hash.c
+++ b/lib/src/crypto/blake2b_hash.c
@@ -320,7 +320,7 @@ cardano_blake2b_hash_to_cbor(
     return CARDANO_POINTER_IS_NULL;
   }
 
-  cardano_error_t write_bytes_result = cardano_cbor_writer_write_byte_string(
+  cardano_error_t write_bytes_result = cardano_cbor_writer_write_bytestring(
     writer,
     cardano_buffer_get_data(blake2b_hash->buffer),
     cardano_buffer_get_size(blake2b_hash->buffer));

--- a/lib/src/plutus_data/plutus_data.c
+++ b/lib/src/plutus_data/plutus_data.c
@@ -658,7 +658,7 @@ cardano_plutus_data_to_cbor(const cardano_plutus_data_t* plutus_data, cardano_cb
 
       if (size <= max_byte_string_chunk_size)
       {
-        result = cardano_cbor_writer_write_byte_string(writer, cardano_buffer_get_data(plutus_data->bytes), size);
+        result = cardano_cbor_writer_write_bytestring(writer, cardano_buffer_get_data(plutus_data->bytes), size);
       }
       else
       {
@@ -675,7 +675,7 @@ cardano_plutus_data_to_cbor(const cardano_plutus_data_t* plutus_data, cardano_cb
 
         for (size_t i = 0; i < chunks; ++i)
         {
-          result = cardano_cbor_writer_write_byte_string(
+          result = cardano_cbor_writer_write_bytestring(
             writer, &cardano_buffer_get_data(plutus_data->bytes)[i * max_byte_string_chunk_size], max_byte_string_chunk_size);
 
           if (result != CARDANO_SUCCESS)
@@ -686,7 +686,7 @@ cardano_plutus_data_to_cbor(const cardano_plutus_data_t* plutus_data, cardano_cb
 
         if (rest > 0U)
         {
-          result = cardano_cbor_writer_write_byte_string(
+          result = cardano_cbor_writer_write_bytestring(
             writer, &cardano_buffer_get_data(plutus_data->bytes)[chunks * max_byte_string_chunk_size], rest);
 
           if (result != CARDANO_SUCCESS)

--- a/lib/src/scripts/plutus_scripts/plutus_v1_script.c
+++ b/lib/src/scripts/plutus_scripts/plutus_v1_script.c
@@ -244,7 +244,7 @@ cardano_plutus_v1_script_to_cbor(
     return CARDANO_POINTER_IS_NULL;
   }
 
-  return cardano_cbor_writer_write_byte_string(
+  return cardano_cbor_writer_write_bytestring(
     writer,
     cardano_buffer_get_data(plutus_v1_script->compiled_code),
     cardano_buffer_get_size(plutus_v1_script->compiled_code));

--- a/lib/src/scripts/plutus_scripts/plutus_v2_script.c
+++ b/lib/src/scripts/plutus_scripts/plutus_v2_script.c
@@ -244,7 +244,7 @@ cardano_plutus_v2_script_to_cbor(
     return CARDANO_POINTER_IS_NULL;
   }
 
-  return cardano_cbor_writer_write_byte_string(
+  return cardano_cbor_writer_write_bytestring(
     writer,
     cardano_buffer_get_data(plutus_v2_script->compiled_code),
     cardano_buffer_get_size(plutus_v2_script->compiled_code));

--- a/lib/src/scripts/plutus_scripts/plutus_v3_script.c
+++ b/lib/src/scripts/plutus_scripts/plutus_v3_script.c
@@ -244,7 +244,7 @@ cardano_plutus_v3_script_to_cbor(
     return CARDANO_POINTER_IS_NULL;
   }
 
-  return cardano_cbor_writer_write_byte_string(
+  return cardano_cbor_writer_write_bytestring(
     writer,
     cardano_buffer_get_data(plutus_v3_script->compiled_code),
     cardano_buffer_get_size(plutus_v3_script->compiled_code));

--- a/lib/tests/allocators_helpers.cpp
+++ b/lib/tests/allocators_helpers.cpp
@@ -114,6 +114,17 @@ fail_after_six_malloc(size_t size)
 }
 
 void*
+fail_after_seventh_malloc(size_t size)
+{
+  if (malloc_run_count < 7)
+  {
+    malloc_run_count++;
+    return malloc(size);
+  }
+  return NULL;
+}
+
+void*
 fail_after_eight_malloc(size_t size)
 {
   if (malloc_run_count < 8)

--- a/lib/tests/allocators_helpers.h
+++ b/lib/tests/allocators_helpers.h
@@ -130,6 +130,18 @@ fail_after_six_malloc(size_t size);
 /**
  * \brief A mock version of malloc that allows eight successful allocation before failing.
  *
+ * This function simulates a scenario where malloc fails after seven malloc (and subsequent calls).
+ *
+ * \param size The size of the memory allocation request.
+ * \return A pointer to allocated memory on the first call, and NULL on subsequent calls
+ *         to simulate allocation failure.
+ */
+void*
+fail_after_seventh_malloc(size_t size);
+
+/**
+ * \brief A mock version of malloc that allows eight successful allocation before failing.
+ *
  * This function simulates a scenario where malloc fails after eight malloc (and subsequent calls).
  *
  * \param size The size of the memory allocation request.


### PR DESCRIPTION
## Description

Update CBOR reader and writers to properly encode bigints as we need this for Plutus Data ints.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [X] I have added tests
    - [X] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?