### PR TITLE
test: fix win32 warnings on tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,9 +183,13 @@ jobs:
         shell: bash
         run: |
           RELEASE_DIR=release/${{ env.RELEASE_NAME }}
-          mkdir -p $RELEASE_DIR
+          mkdir -p $RELEASE_DIR/lib
+          cp README %RELEASE_DIR%/
+          cp LICENSE %RELEASE_DIR%/
           cp -r lib/include $RELEASE_DIR/
-          cp build/release/lib/* $RELEASE_DIR/ 2>/dev/null || true
+          cp build/release/lib/*.so $RELEASE_DIR/lib 2>/dev/null || true
+          cp build/release/lib/*.a $RELEASE_DIR/lib 2>/dev/null || true
+          cp build/release/lib/*.pc $RELEASE_DIR/lib 2>/dev/null || true
           tar -czf "${{ env.RELEASE_NAME }}.tar.gz" -C release/${{ env.RELEASE_NAME }} .
 
       # Package binaries (Windows MSVC)
@@ -195,16 +199,21 @@ jobs:
         run: |
           set RELEASE_DIR=release\%RELEASE_NAME%
           mkdir %RELEASE_DIR%
+          mkdir %RELEASE_DIR%\lib
           
+          # Copy include files
           xcopy /E /I lib\include %RELEASE_DIR%\include
-
+          
+          # Copy .dll and .lib files into /lib
           for %%f in (dll lib) do (
-              xcopy /Y build\release\lib\Release\*.%%f %RELEASE_DIR%\
+              xcopy /Y build\release\lib\Release\*.%%f %RELEASE_DIR%\lib\
           )
-
+          
+          # Copy README and LICENSE files
           xcopy /Y README %RELEASE_DIR%\
           xcopy /Y LICENSE %RELEASE_DIR%\
           
+          # Compress the release directory
           powershell Compress-Archive -Path %RELEASE_DIR%\* -DestinationPath %RELEASE_NAME%.zip
 
       # Package binaries (Windows MinGW)
@@ -213,11 +222,12 @@ jobs:
         shell: bash
         run: |
           RELEASE_DIR=release/${{ env.RELEASE_NAME }}
-          mkdir -p $RELEASE_DIR
+          mkdir -p $RELEASE_DIR/lib
           cp -r lib/include $RELEASE_DIR/
           cp README %RELEASE_DIR%/
           cp LICENSE %RELEASE_DIR%/
-          cp build/release/lib/Release* $RELEASE_DIR/ 2>/dev/null || true
+          cp build/release/lib/release/*.dll $RELEASE_DIR/lib 2>/dev/null || true
+          cp build/release/lib/release/*.dll.a $RELEASE_DIR/lib 2>/dev/null || true
           7z a "${{ env.RELEASE_NAME }}.zip" $RELEASE_DIR
 
       # Upload artifacts to GitHub Release (Unix)
@@ -228,8 +238,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: release-${{ env.RELEASE_NAME }}.tar.gz
-          asset_name: release-${{ env.RELEASE_NAME }}.tar.gz
+          asset_path: ${{ env.RELEASE_NAME }}.tar.gz
+          asset_name: ${{ env.RELEASE_NAME }}.tar.gz
           asset_content_type: application/gzip
 
       # Upload artifacts to GitHub Release (Windows)
@@ -240,6 +250,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: release-${{ env.RELEASE_NAME }}.zip
-          asset_name: release-${{ env.RELEASE_NAME }}.zip
+          asset_path: ${{ env.RELEASE_NAME }}.zip
+          asset_name: ${{ env.RELEASE_NAME }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/windows-unit-test.yml
+++ b/.github/workflows/windows-unit-test.yml
@@ -21,7 +21,7 @@ jobs:
           mkdir -p gtest-build
           cd gtest-build
           curl -L -o googletest-release-1.11.0.zip https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-          tar -xf googletest-release-1.11.0.zip
+          unzip googletest-release-1.11.0.zip
           cd googletest-release-1.11.0
           cmake -G "Visual Studio 17 2022" -A x64 \
             -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" \
@@ -59,7 +59,7 @@ jobs:
           mkdir -p gtest-build
           cd gtest-build
           curl -L -o googletest-release-1.11.0.zip https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-          tar -xf googletest-release-1.11.0.zip
+          unzip googletest-release-1.11.0.zip
           cd googletest-release-1.11.0
           cmake -G "Visual Studio 17 2022" -A Win32 \
             -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" \

--- a/lib/tests/cbor/cbor_reader.cpp
+++ b/lib/tests/cbor/cbor_reader.cpp
@@ -2275,7 +2275,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfBufferIsNull)
 {
   cardano_buffer_t* buffer     = nullptr;
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0, &value, &bytes_read);
@@ -2287,7 +2287,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfAdditionalInfoIs8BitsAnd
   const char*       cbor_hex   = "18";
   cardano_buffer_t* buffer     = cardano_buffer_from_hex(cbor_hex, strlen(cbor_hex));
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0xf8, &value, &bytes_read);
@@ -2302,7 +2302,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfAdditionalInfoIs16BitsAn
   const char*       cbor_hex   = "18";
   cardano_buffer_t* buffer     = cardano_buffer_from_hex(cbor_hex, strlen(cbor_hex));
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0xf9, &value, &bytes_read);
@@ -2317,7 +2317,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfAdditionalInfoIs32BitsAn
   const char*       cbor_hex   = "18";
   cardano_buffer_t* buffer     = cardano_buffer_from_hex(cbor_hex, strlen(cbor_hex));
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0xfa, &value, &bytes_read);
@@ -2332,7 +2332,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfAdditionalInfoIs64BitsAn
   const char*       cbor_hex   = "18";
   cardano_buffer_t* buffer     = cardano_buffer_from_hex(cbor_hex, strlen(cbor_hex));
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0xfb, &value, &bytes_read);
@@ -2347,7 +2347,7 @@ TEST(_cbor_reader_decode_unsigned_integer, returnErrorIfAdditionalInfoIsUnknown)
   const char*       cbor_hex   = "18";
   cardano_buffer_t* buffer     = cardano_buffer_from_hex(cbor_hex, strlen(cbor_hex));
   uint64_t          value      = 0;
-  uint64_t          bytes_read = 0;
+  size_t            bytes_read = 0;
 
   // Act
   cardano_error_t result = _cbor_reader_decode_unsigned_integer(buffer, 0xff, &value, &bytes_read);

--- a/lib/tests/transaction_body/value.cpp
+++ b/lib/tests/transaction_body/value.cpp
@@ -1598,7 +1598,7 @@ TEST(cardano_value_get_intersection_count, canGetIntersectionCount)
   // Arrange
   cardano_value_t* value1 = new_default_value(CBOR);
   cardano_value_t* value2 = new_default_value(CBOR_VALUE_WITH_TWICE_THE_ASSETS);
-  size_t           result = 0;
+  uint64_t         result = 0;
 
   // Act
   cardano_error_t error = cardano_value_get_intersection_count(value1, value2, &result);
@@ -1618,7 +1618,7 @@ TEST(cardano_value_get_intersection_count, canGetIntersectionCount2)
   // Arrange
   cardano_value_t* value1 = new_default_value(CBOR);
   cardano_value_t* value2 = new_default_value(CBOR2);
-  size_t           result = 0;
+  uint64_t         result = 0;
 
   // Act
   cardano_error_t error = cardano_value_get_intersection_count(value1, value2, &result);
@@ -1638,7 +1638,7 @@ TEST(cardano_value_get_intersection_count, canGetIntersectionCountOfOnlyAda)
   // Arrange
   cardano_value_t* value1 = new_default_value(CBOR);
   cardano_value_t* value2 = new_default_value("01");
-  size_t           result = 0;
+  uint64_t         result = 0;
 
   // Act
   cardano_error_t error = cardano_value_get_intersection_count(value1, value2, &result);
@@ -1657,7 +1657,7 @@ TEST(cardano_value_get_intersection_count, returnsErrorIfLshIsNull)
 {
   // Arrange
   cardano_value_t* value2 = new_default_value(CBOR);
-  size_t           result = 0;
+  uint64_t         result = 0;
 
   // Act
   cardano_error_t error = cardano_value_get_intersection_count(nullptr, value2, &result);
@@ -1673,7 +1673,7 @@ TEST(cardano_value_get_intersection_count, returnsErrorIfRhsIsNull)
 {
   // Arrange
   cardano_value_t* value1 = new_default_value(CBOR);
-  size_t           result = 0;
+  uint64_t         result = 0;
 
   // Act
   cardano_error_t error = cardano_value_get_intersection_count(value1, nullptr, &result);

--- a/lib/tests/transaction_builder/fee.cpp
+++ b/lib/tests/transaction_builder/fee.cpp
@@ -310,7 +310,7 @@ TEST(cardano_fee_get_serialized_coin_size, returnsErrorIfMemoryAllocationFails)
   reset_allocators_run_count();
   cardano_set_allocators(fail_right_away_malloc, realloc, free);
 
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_coin_size(0, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_MEMORY_ALLOCATION_FAILED);
@@ -327,7 +327,7 @@ TEST(cardano_fee_get_serialized_output_size, returnsErrorIfOutParamIsNull)
 
 TEST(cardano_fee_get_serialized_output_size, returnsErrorIfOutputIsNull)
 {
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_output_size(NULL, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
@@ -340,7 +340,7 @@ TEST(cardano_fee_get_serialized_output_size, returnsErrorIfMemoryAllocationFails
   reset_allocators_run_count();
   cardano_set_allocators(fail_right_away_malloc, realloc, free);
 
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_output_size(output, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_MEMORY_ALLOCATION_FAILED);
@@ -358,7 +358,7 @@ TEST(cardano_fee_gget_serialized_script_size, returnsErrorIfOutParamIsNull)
 
 TEST(cardano_fee_gget_serialized_script_size, returnsErrorIfScriptIsNull)
 {
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_script_size(NULL, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
@@ -369,7 +369,7 @@ TEST(cardano_fee_get_serialized_script_size, returnsErrorIfMemoryAllocationFails
   reset_allocators_run_count();
   cardano_set_allocators(fail_right_away_malloc, realloc, free);
 
-  uint64_t size = 0U;
+  size_t size = 0U;
 
   cardano_error_t result = cardano_get_serialized_script_size((cardano_script_t*)"", &size);
 
@@ -387,7 +387,7 @@ TEST(cardano_fee_get_serialized_transaction_size, returnsErrorIfOutParamIsNull)
 
 TEST(cardano_fee_get_serialized_transaction_size, returnsErrorIfTransactionIsNull)
 {
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_transaction_size(NULL, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
@@ -400,7 +400,7 @@ TEST(cardano_fee_get_serialized_transaction_size, returnsErrorIfMemoryAllocation
   reset_allocators_run_count();
   cardano_set_allocators(fail_right_away_malloc, realloc, free);
 
-  uint64_t        size   = 0U;
+  size_t          size   = 0U;
   cardano_error_t result = cardano_get_serialized_transaction_size(tx, &size);
 
   EXPECT_EQ(result, CARDANO_ERROR_MEMORY_ALLOCATION_FAILED);


### PR DESCRIPTION
## Description

Fixed a few warnings on some tests on MinGW 32 bits environment

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/Biglup/cardano-c/blob/master/CONTRIBUTING.md)
    - [x] I have added tests
    - [x] I have updated the documentation
    - [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
    - [ ] If yes: I have marked them in the CHANGELOG
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?