### PR TITLE
refactor: extract the transaction builder core into composable internals

### DIFF
--- a/lib/src/transaction_builder/internals/builder_build.c
+++ b/lib/src/transaction_builder/internals/builder_build.c
@@ -1,0 +1,331 @@
+/**
+ * \file builder_build.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_build.h"
+
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/protocol_params/cost_model.h>
+#include <cardano/protocol_params/costmdls.h>
+#include <cardano/scripts/plutus_scripts/plutus_language_version.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/transaction_builder/balancing/transaction_balancing.h>
+#include <cardano/transaction_builder/script_data_hash.h>
+#include <cardano/witness_set/plutus_data_set.h>
+#include <cardano/witness_set/redeemer_list.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include <assert.h>
+
+/* STATIC DECLARATIONS *******************************************************/
+
+/**
+ * \brief Sets a dummy script data hash in the transaction.
+ *
+ * This function assigns a placeholder script data hash to the specified transaction for fee calculation
+ * purposes when the transaction includes script data.
+ *
+ * \param[in,out] tx A pointer to a \ref cardano_transaction_t object representing the transaction to which
+ *                   the dummy script data hash will be set. This parameter must not be NULL.
+ *
+ * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the dummy
+ *         script data hash was successfully set, or an appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+set_dummy_script_data_hash(cardano_transaction_t* tx)
+{
+  if (!cardano_transaction_has_script_data(tx))
+  {
+    return CARDANO_SUCCESS;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx);
+  cardano_transaction_body_unref(&body);
+
+  static byte_t           dummy_hash[32] = { 0 };
+  cardano_blake2b_hash_t* hash           = NULL;
+
+  cardano_error_t new_hash_result = cardano_blake2b_hash_from_bytes(dummy_hash, sizeof(dummy_hash), &hash);
+
+  if (new_hash_result != CARDANO_SUCCESS)
+  {
+    return new_hash_result;
+  }
+
+  new_hash_result = cardano_transaction_body_set_script_data_hash(body, hash);
+  cardano_blake2b_hash_unref(&hash);
+
+  if (new_hash_result != CARDANO_SUCCESS)
+  {
+    return new_hash_result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * \brief Retrieves the cost model for a specified Plutus language version.
+ *
+ * This function searches for the cost model matching the specified Plutus language version within a
+ * provided set of source cost models and, if found, copies it into a destination cost model set.
+ *
+ * \param[in] source_models A pointer to the \ref cardano_costmdls_t object containing the source cost models.
+ * \param[out] dest_models A pointer to the \ref cardano_costmdls_t object where the matching cost model
+ *                         for the specified version will be copied. This parameter must not be NULL.
+ * \param[in] version The Plutus language version of the cost model to retrieve.
+ *
+ * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the cost model
+ *         was successfully found and copied, or an appropriate error code if an internal error occurs.
+ */
+static cardano_error_t
+get_cost_model_for_version(
+  cardano_costmdls_t*                     source_models,
+  cardano_costmdls_t*                     dest_models,
+  const cardano_plutus_language_version_t version)
+{
+  assert(source_models != NULL);
+  assert(dest_models != NULL);
+
+  cardano_cost_model_t* cost_model = NULL;
+
+  cardano_error_t result = cardano_costmdls_get(source_models, version, &cost_model);
+  cardano_cost_model_unref(&cost_model);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_costmdls_insert(dest_models, cost_model);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+/**
+ * \brief Retrieves the cost models flagged by the builder state.
+ *
+ * \param[in] state A pointer to the \ref cardano_builder_state_t instance from which the cost models will be retrieved.
+ * \param[out] costmdls A pointer to an initialized \ref cardano_costmdls_t object where the cost models will be stored.
+ *                      This parameter must not be NULL.
+ *
+ * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the cost models
+ *         were successfully retrieved and stored, or an appropriate error code if an error occurs during retrieval.
+ */
+static cardano_error_t
+get_cost_models(cardano_builder_state_t* state, cardano_costmdls_t* costmdls)
+{
+  cardano_costmdls_t* pparams_costmdls = cardano_protocol_parameters_get_cost_models(state->params);
+  cardano_costmdls_unref(&pparams_costmdls);
+
+  cardano_error_t result = CARDANO_SUCCESS;
+
+  if (state->has_plutus_v1)
+  {
+    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V1);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  if (state->has_plutus_v2)
+  {
+    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V2);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  if (state->has_plutus_v3)
+  {
+    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V3);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * \brief Computes and updates the script data hash in a transaction.
+ *
+ * This function calculates the script data hash based on the redeemers, datums, and cost models
+ * associated with the transaction in the \ref cardano_builder_state_t instance, then updates this
+ * hash in the provided \ref cardano_transaction_t.
+ *
+ * \param[in] state A pointer to the \ref cardano_builder_state_t instance containing the necessary
+ *                  transaction data, including redeemers, datums, and cost models.
+ * \param[in,out] tx A pointer to an initialized \ref cardano_transaction_t object. This transaction
+ *                   will be updated with the computed script data hash.
+ *
+ * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS
+ *         if the script data hash was successfully computed and updated in the transaction, or an
+ *         appropriate error code if the computation or update fails.
+ */
+static cardano_error_t
+update_script_data_hash(cardano_builder_state_t* state, cardano_transaction_t* tx)
+{
+  if (!cardano_transaction_has_script_data(tx))
+  {
+    return CARDANO_SUCCESS;
+  }
+
+  cardano_costmdls_t* costmdls = NULL;
+
+  cardano_error_t result = cardano_costmdls_new(&costmdls);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = get_cost_models(state, costmdls);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_costmdls_unref(&costmdls);
+    return result;
+  }
+
+  cardano_blake2b_hash_t* hash = NULL;
+
+  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(tx);
+  cardano_witness_set_unref(&witness_set);
+
+  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witness_set);
+  cardano_redeemer_list_unref(&redeemers);
+
+  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witness_set);
+  cardano_plutus_data_set_unref(&datums);
+
+  result = cardano_compute_script_data_hash(costmdls, redeemers, datums, &hash);
+  cardano_costmdls_unref(&costmdls);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_blake2b_hash_unref(&hash);
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx);
+  cardano_transaction_body_unref(&body);
+
+  result = cardano_transaction_body_set_script_data_hash(body, hash);
+  cardano_blake2b_hash_unref(&hash);
+
+  return result;
+}
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_build(
+  cardano_builder_state_t* state,
+  cardano_transaction_t**  transaction,
+  const char**             error_message)
+{
+  if (state->change_address == NULL)
+  {
+    *error_message = "You must set a change address before calling `build`.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (state->available_utxos == NULL)
+  {
+    *error_message = "You must set the available UTXOs for input selection before calling `build`.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (cardano_transaction_has_script_data(state->transaction))
+  {
+    if (state->collateral_address == NULL)
+    {
+      *error_message = "This transaction interacts with plutus validators. You must set a collateral change address before calling `build`.";
+
+      return CARDANO_ERROR_POINTER_IS_NULL;
+    }
+
+    if (state->collateral_utxos == NULL)
+    {
+      *error_message = "This transaction interacts with plutus validators. You must set the collateral UTXOs before calling `build`.";
+
+      return CARDANO_ERROR_POINTER_IS_NULL;
+    }
+  }
+
+  cardano_transaction_t* tx = state->transaction;
+
+  cardano_error_t result = set_dummy_script_data_hash(tx);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_balance_transaction(
+    tx,
+    state->additional_signature_count,
+    state->params,
+    state->reference_inputs,
+    state->pre_selected_inputs,
+    state->input_to_redeemer_map,
+    state->available_utxos,
+    state->coin_selector,
+    state->change_address,
+    state->collateral_utxos,
+    state->collateral_address,
+    state->tx_evaluator,
+    state->deferred_redeemers);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = cardano_transaction_get_last_error(tx);
+
+    return result;
+  }
+
+  result = update_script_data_hash(state, tx);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_transaction_ref(tx);
+  *transaction = tx;
+
+  return CARDANO_SUCCESS;
+}

--- a/lib/src/transaction_builder/internals/builder_build.h
+++ b/lib/src/transaction_builder/internals/builder_build.h
@@ -1,0 +1,73 @@
+/**
+ * \file builder_build.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_BUILD_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_BUILD_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+#include <cardano/transaction/transaction.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Balances and finalizes the transaction under construction.
+ *
+ * This function verifies that a change address and an available UTXO list were configured, and that
+ * a collateral change address and collateral UTXOs were configured when the transaction interacts
+ * with Plutus validators. It then sets a placeholder script data hash for fee calculation when the
+ * transaction carries script data, balances the transaction using the configured protocol
+ * parameters, coin selector and transaction evaluator, recomputes the script data hash from the
+ * final redeemers, datums and cost models, and returns the finalized transaction with a new
+ * reference.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[out] transaction A pointer to a pointer that receives the finalized
+ *                         \ref cardano_transaction_t. The caller must release it with
+ *                         \ref cardano_transaction_unref. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS, or is left untouched
+ *                           when the failing operation does not report a message. The string is
+ *                           either static or owned by the transaction held by the state. It is left
+ *                           untouched on success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the transaction was balanced and finalized, or an appropriate
+ *         error code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_build(
+  cardano_builder_state_t* state,
+  cardano_transaction_t**  transaction,
+  const char**             error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_BUILD_H

--- a/lib/src/transaction_builder/internals/builder_certs.c
+++ b/lib/src/transaction_builder/internals/builder_certs.c
@@ -1,0 +1,939 @@
+/**
+ * \file builder_certs.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_certs.h"
+
+#include <cardano/certs/certificate_set.h>
+#include <cardano/certs/register_drep_cert.h>
+#include <cardano/certs/registration_cert.h>
+#include <cardano/certs/stake_delegation_cert.h>
+#include <cardano/certs/unregister_drep_cert.h>
+#include <cardano/certs/unregistration_cert.h>
+#include <cardano/certs/update_drep_cert.h>
+#include <cardano/certs/vote_delegation_cert.h>
+#include <cardano/common/ex_units.h>
+#include <cardano/encoding/bech32.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/witness_set/redeemer_list.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "builder_redeemers.h"
+
+#include <string.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_add_certificate(
+  cardano_builder_state_t* state,
+  cardano_certificate_t*   certificate,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (certificate == NULL)
+  {
+    *error_message = "Certificate is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
+
+  if (certs == NULL)
+  {
+    cardano_error_t result = cardano_certificate_set_new(&certs);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create certificate set.";
+
+      return result;
+    }
+
+    result = cardano_transaction_body_set_certificates(body, certs);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set certificate set.";
+      cardano_certificate_set_unref(&certs);
+
+      return result;
+    }
+  }
+
+  cardano_certificate_set_unref(&certs);
+
+  cardano_error_t result = cardano_certificate_set_add(certs, certificate);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add certificate.";
+
+    return result;
+  }
+
+  if (redeemer != NULL)
+  {
+    cardano_redeemer_t* rdmer = NULL;
+
+    cardano_ex_units_t* ex_units = NULL;
+    result                       = cardano_ex_units_new(0, 0, &ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create execution units.";
+
+      return result;
+    }
+
+    const size_t certs_size = cardano_certificate_set_get_length(certs);
+
+    if (certs_size == 0U)
+    {
+      cardano_redeemer_unref(&rdmer);
+      *error_message = "Unexpected empty certificate set.";
+
+      return CARDANO_ERROR_INVALID_ARGUMENT;
+    }
+
+    const size_t cert_index = cardano_certificate_set_get_length(certs) - 1U;
+
+    result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_CERTIFYING, cert_index, redeemer, ex_units, &rdmer);
+    cardano_ex_units_unref(&ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create redeemer.";
+
+      return result;
+    }
+
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+    cardano_witness_set_unref(&witnesses);
+
+    cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
+
+    if (redeemers == NULL)
+    {
+      result = cardano_redeemer_list_new(&redeemers);
+
+      if (result != CARDANO_SUCCESS)
+      {
+        cardano_redeemer_unref(&rdmer);
+        *error_message = "Failed to create redeemer list.";
+
+        return result;
+      }
+
+      result = cardano_witness_set_set_redeemers(witnesses, redeemers);
+
+      if (result != CARDANO_SUCCESS)
+      {
+        cardano_redeemer_unref(&rdmer);
+        *error_message = "Failed to set redeemer list.";
+        cardano_redeemer_list_unref(&redeemers);
+
+        return result;
+      }
+    }
+
+    cardano_redeemer_list_unref(&redeemers);
+
+    result = cardano_redeemer_list_add(redeemers, rdmer);
+    cardano_redeemer_unref(&rdmer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add redeemer.";
+
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_register_reward_address(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Reward address is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(state->params);
+
+  cardano_certificate_t*       cert         = NULL;
+  cardano_registration_cert_t* registration = NULL;
+  cardano_error_t              result       = cardano_registration_cert_new(credential, deposit, &registration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create registration certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_registration(registration, &cert);
+  cardano_registration_cert_unref(&registration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_register_reward_address_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_reward_address_t* addr   = NULL;
+  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  result = cardano_builder_register_reward_address(state, addr, redeemer, error_message);
+  cardano_reward_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_deregister_reward_address(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Reward address is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(state->params);
+
+  cardano_certificate_t*         cert           = NULL;
+  cardano_unregistration_cert_t* unregistration = NULL;
+
+  cardano_error_t result = cardano_unregistration_cert_new(credential, deposit, &unregistration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create unregistration certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_unregistration(unregistration, &cert);
+  cardano_unregistration_cert_unref(&unregistration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_deregister_reward_address_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+
+  cardano_error_t result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  result = cardano_builder_deregister_reward_address(state, addr, redeemer, error_message);
+  cardano_reward_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_delegate_stake(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_blake2b_hash_t*   pool_id,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Reward address is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (pool_id == NULL)
+  {
+    *error_message = "Pool ID is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  cardano_certificate_t*           cert       = NULL;
+  cardano_stake_delegation_cert_t* delegation = NULL;
+
+  cardano_error_t result = cardano_stake_delegation_cert_new(credential, pool_id, &delegation);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create delegation certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_stake_delegation(delegation, &cert);
+  cardano_stake_delegation_cert_unref(&delegation);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_delegate_stake_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  const char*              pool_id,
+  size_t                   pool_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((pool_id == NULL) || (pool_id_size == 0U))
+  {
+    *error_message = "Pool ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  byte_t pool_id_hex[28] = { 0 };
+  char   pool_hrp[5]     = { 0 };
+
+  cardano_error_t result = cardano_encoding_bech32_decode(pool_id, pool_id_size, pool_hrp, sizeof(pool_hrp), pool_id_hex, sizeof(pool_id_hex));
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to decode pool ID.";
+
+    return result;
+  }
+
+  if (strncmp(pool_hrp, "pool", 4) != 0)
+  {
+    *error_message = "Invalid pool ID.";
+
+    return CARDANO_ERROR_INVALID_ARGUMENT;
+  }
+
+  cardano_blake2b_hash_t* hash = NULL;
+  result                       = cardano_blake2b_hash_from_bytes(pool_id_hex, sizeof(pool_id_hex), &hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse pool ID.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_blake2b_hash_unref(&hash);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  result = cardano_builder_delegate_stake(state, addr, hash, redeemer, error_message);
+  cardano_reward_address_unref(&addr);
+  cardano_blake2b_hash_unref(&hash);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_delegate_voting_power(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_drep_t*           drep,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Reward address is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (drep == NULL)
+  {
+    *error_message = "DREP is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  cardano_certificate_t*          cert       = NULL;
+  cardano_vote_delegation_cert_t* delegation = NULL;
+
+  cardano_error_t result = cardano_vote_delegation_cert_new(credential, drep, &delegation);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create delegation certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_vote_delegation(delegation, &cert);
+  cardano_vote_delegation_cert_unref(&delegation);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_delegate_voting_power_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((drep_id == NULL) || (drep_id_size == 0U))
+  {
+    *error_message = "DREP ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_reward_address_t* addr   = NULL;
+  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_drep_t* drep = NULL;
+  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse DREP ID.";
+    cardano_reward_address_unref(&addr);
+
+    return result;
+  }
+
+  result = cardano_builder_delegate_voting_power(state, addr, drep, redeemer, error_message);
+
+  cardano_reward_address_unref(&addr);
+  cardano_drep_unref(&drep);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_register_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_anchor_t*        anchor,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (drep == NULL)
+  {
+    *error_message = "DRep is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_certificate_t*        cert          = NULL;
+  cardano_register_drep_cert_t* register_drep = NULL;
+  cardano_credential_t*         credential    = NULL;
+
+  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
+  cardano_credential_unref(&credential);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to get credential.";
+
+    return result;
+  }
+
+  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(state->params);
+  result                 = cardano_register_drep_cert_new(credential, deposit, anchor, &register_drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create DRep registration certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_register_drep(register_drep, &cert);
+  cardano_register_drep_cert_unref(&register_drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_register_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  const size_t             drep_id_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((drep_id == NULL) || (drep_id_size == 0U))
+  {
+    *error_message = "DRep ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_drep_t* drep = NULL;
+  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse DRep ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_register_drep(state, drep, anchor, redeemer, error_message);
+
+  cardano_drep_unref(&drep);
+  cardano_anchor_unref(&anchor);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_update_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_anchor_t*        anchor,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (drep == NULL)
+  {
+    *error_message = "DRep is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_certificate_t*      cert        = NULL;
+  cardano_update_drep_cert_t* update_drep = NULL;
+  cardano_credential_t*       credential  = NULL;
+
+  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
+  cardano_credential_unref(&credential);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to get credential.";
+
+    return result;
+  }
+
+  result = cardano_update_drep_cert_new(credential, anchor, &update_drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create DRep update certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_update_drep(update_drep, &cert);
+  cardano_update_drep_cert_unref(&update_drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_update_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  const size_t             drep_id_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((drep_id == NULL) || (drep_id_size == 0U))
+  {
+    *error_message = "DRep ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_drep_t* drep = NULL;
+  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse DRep ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_update_drep(state, drep, anchor, redeemer, error_message);
+
+  cardano_drep_unref(&drep);
+  cardano_anchor_unref(&anchor);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_deregister_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (drep == NULL)
+  {
+    *error_message = "DRep is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_certificate_t*          cert           = NULL;
+  cardano_unregister_drep_cert_t* deregistration = NULL;
+  cardano_credential_t*           credential     = NULL;
+
+  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
+  cardano_credential_unref(&credential);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to get credential.";
+
+    return result;
+  }
+
+  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(state->params);
+  result                 = cardano_unregister_drep_cert_new(credential, deposit, &deregistration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create DRep deregistration certificate.";
+
+    return result;
+  }
+
+  result = cardano_certificate_new_unregister_drep(deregistration, &cert);
+  cardano_unregister_drep_cert_unref(&deregistration);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create certificate.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, cert, redeemer, error_message);
+  cardano_certificate_unref(&cert);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_deregister_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((drep_id == NULL) || (drep_id_size == 0U))
+  {
+    *error_message = "DRep ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_drep_t* drep   = NULL;
+  cardano_error_t result = cardano_drep_from_string(drep_id, drep_id_size, &drep);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse DRep ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_deregister_drep(state, drep, redeemer, error_message);
+  cardano_drep_unref(&drep);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_add_certificate_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_certificate_t*         certificate,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message)
+{
+  if ((certificate == NULL) || (callback == NULL))
+  {
+    *error_message = "Certificate and callback are required";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_plutus_data_t* placeholder = NULL;
+
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create the placeholder redeemer.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_certificate(state, certificate, placeholder, error_message);
+
+  cardano_plutus_data_unref(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
+  cardano_certificate_set_unref(&certs);
+
+  const uint64_t cert_index = (uint64_t)(cardano_certificate_set_get_length(certs) - 1U);
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witnesses);
+
+  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
+  cardano_redeemer_list_unref(&redeemers);
+
+  result = CARDANO_ERROR_ELEMENT_NOT_FOUND;
+
+  const size_t redeemer_count = cardano_redeemer_list_get_length(redeemers);
+
+  for (size_t i = 0U; (i < redeemer_count) && (result == CARDANO_ERROR_ELEMENT_NOT_FOUND); ++i)
+  {
+    cardano_redeemer_t* redeemer = NULL;
+
+    const cardano_error_t get_result = cardano_redeemer_list_get(redeemers, i, &redeemer);
+
+    if (get_result != CARDANO_SUCCESS)
+    {
+      result = get_result;
+      break;
+    }
+
+    const bool matches = (cardano_redeemer_get_tag(redeemer) == CARDANO_REDEEMER_TAG_CERTIFYING) &&
+      (cardano_redeemer_get_index(redeemer) == cert_index);
+
+    if (matches)
+    {
+      result = cardano_deferred_redeemer_list_add(state->deferred_redeemers, redeemer, callback, user_context);
+    }
+
+    cardano_redeemer_unref(&redeemer);
+  }
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to register the deferred redeemer.";
+  }
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_certs.h
+++ b/lib/src/transaction_builder/internals/builder_certs.h
@@ -1,0 +1,513 @@
+/**
+ * \file builder_certs.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CERTS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CERTS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/reward_address.h>
+#include <cardano/certs/certificate.h>
+#include <cardano/common/anchor.h>
+#include <cardano/common/drep.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Appends a certificate to the transaction.
+ *
+ * This function adds \p certificate to the certificate set of the transaction body, creating the
+ * set when it is missing. When \p redeemer is not NULL a certifying redeemer with the index of the
+ * appended certificate and zero execution units is created and appended to the witness set redeemer
+ * list, creating the list when it is missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] certificate A pointer to the \ref cardano_certificate_t to add. This parameter must not
+ *                        be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the certificate does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_add_certificate(
+  cardano_builder_state_t* state,
+  cardano_certificate_t*   certificate,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a stake registration certificate for a reward address.
+ *
+ * This function creates a registration certificate for the credential of \p address using the key
+ * deposit from the state protocol parameters and delegates to \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t to register. This parameter must
+ *                    not be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_register_reward_address(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message);
+
+/**
+ * \brief Adds a stake registration certificate given the reward address as a bech32 string.
+ *
+ * This function parses the reward address and delegates to
+ * \ref cardano_builder_register_reward_address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] address_size The size of the reward address string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_register_reward_address_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a stake unregistration certificate for a reward address.
+ *
+ * This function creates an unregistration certificate for the credential of \p address using the
+ * key deposit from the state protocol parameters and delegates to
+ * \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t to deregister. This parameter
+ *                    must not be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_deregister_reward_address(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message);
+
+/**
+ * \brief Adds a stake unregistration certificate given the reward address as a bech32 string.
+ *
+ * This function parses the reward address and delegates to
+ * \ref cardano_builder_deregister_reward_address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] address_size The size of the reward address string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_deregister_reward_address_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a stake delegation certificate for a reward address and a pool.
+ *
+ * This function creates a stake delegation certificate delegating the credential of \p address to
+ * the pool identified by \p pool_id and delegates to \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t whose stake is delegated. This
+ *                    parameter must not be NULL.
+ * \param[in] pool_id A pointer to the \ref cardano_blake2b_hash_t with the pool key hash. This
+ *                    parameter must not be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_delegate_stake(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_blake2b_hash_t*   pool_id,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message);
+
+/**
+ * \brief Adds a stake delegation certificate given the reward address and pool id as bech32 strings.
+ *
+ * This function decodes the pool id, requiring the pool prefix, parses the reward address and
+ * delegates to \ref cardano_builder_delegate_stake.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] address_size The size of the reward address string in bytes.
+ * \param[in] pool_id A pointer to the bech32 string with the pool id.
+ * \param[in] pool_id_size The size of the pool id string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_delegate_stake_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  const char*              pool_id,
+  size_t                   pool_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a vote delegation certificate for a reward address and a DRep.
+ *
+ * This function creates a vote delegation certificate delegating the voting power of the credential
+ * of \p address to \p drep and delegates to \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t whose voting power is delegated.
+ *                    This parameter must not be NULL.
+ * \param[in] drep A pointer to the \ref cardano_drep_t receiving the voting power. This parameter
+ *                 must not be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_delegate_voting_power(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  cardano_drep_t*           drep,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message);
+
+/**
+ * \brief Adds a vote delegation certificate given the reward address and DRep id as strings.
+ *
+ * This function parses the reward address and the DRep id and delegates to
+ * \ref cardano_builder_delegate_voting_power.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] address_size The size of the reward address string in bytes.
+ * \param[in] drep_id A pointer to the string with the DRep id.
+ * \param[in] drep_id_size The size of the DRep id string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_delegate_voting_power_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep registration certificate.
+ *
+ * This function creates a DRep registration certificate for the credential of \p drep using the
+ * DRep deposit from the state protocol parameters and the optional \p anchor, and delegates to
+ * \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep A pointer to the \ref cardano_drep_t to register. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the DRep metadata, or NULL when the
+ *                   DRep has none.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_register_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_anchor_t*        anchor,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep registration certificate given the DRep id and metadata as strings.
+ *
+ * This function creates the metadata anchor from the url and hash strings, parses the DRep id and
+ * delegates to \ref cardano_builder_register_drep.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep_id A pointer to the string with the DRep id.
+ * \param[in] drep_id_size The size of the DRep id string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata url.
+ * \param[in] metadata_url_size The size of the metadata url string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hexadecimal string with the metadata hash.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_register_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep update certificate.
+ *
+ * This function creates a DRep update certificate for the credential of \p drep carrying the
+ * optional \p anchor and delegates to \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep A pointer to the \ref cardano_drep_t to update. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the DRep metadata, or NULL when the
+ *                   DRep has none.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_update_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_anchor_t*        anchor,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep update certificate given the DRep id and metadata as strings.
+ *
+ * This function creates the metadata anchor from the url and hash strings, parses the DRep id and
+ * delegates to \ref cardano_builder_update_drep.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep_id A pointer to the string with the DRep id.
+ * \param[in] drep_id_size The size of the DRep id string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata url.
+ * \param[in] metadata_url_size The size of the metadata url string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hexadecimal string with the metadata hash.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_update_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep deregistration certificate.
+ *
+ * This function creates a DRep deregistration certificate for the credential of \p drep using the
+ * DRep deposit from the state protocol parameters and delegates to
+ * \ref cardano_builder_add_certificate.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep A pointer to the \ref cardano_drep_t to deregister. This parameter must not be
+ *                 NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_deregister_drep(
+  cardano_builder_state_t* state,
+  cardano_drep_t*          drep,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Adds a DRep deregistration certificate given the DRep id as a string.
+ *
+ * This function parses the DRep id and delegates to \ref cardano_builder_deregister_drep.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] drep_id A pointer to the string with the DRep id.
+ * \param[in] drep_id_size The size of the DRep id string in bytes.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as certifying redeemer
+ *                     payload, or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_deregister_drep_ex(
+  cardano_builder_state_t* state,
+  const char*              drep_id,
+  size_t                   drep_id_size,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Appends a certificate whose redeemer payload is resolved during balancing.
+ *
+ * This function appends the certificate with an empty placeholder redeemer, finds the certifying
+ * redeemer created for it in the witness set redeemer list and registers the callback for it in the
+ * state deferred redeemer list. The callback is invoked while the transaction is balanced to produce
+ * the final redeemer payload.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] certificate A pointer to the \ref cardano_certificate_t to add. This parameter must not
+ *                        be NULL.
+ * \param[in] callback The deferred redeemer callback invoked during balancing. This parameter must
+ *                     not be NULL.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the certificate and callback were registered, or an appropriate
+ *         error code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_add_certificate_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_certificate_t*         certificate,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CERTS_H

--- a/lib/src/transaction_builder/internals/builder_config.c
+++ b/lib/src/transaction_builder/internals/builder_config.c
@@ -1,0 +1,510 @@
+/**
+ * \file builder_config.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_config.h"
+
+#include <cardano/auxiliary_data/auxiliary_data.h>
+#include <cardano/auxiliary_data/transaction_metadata.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/time.h>
+#include <cardano/transaction_body/transaction_body.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_set_coin_selector(
+  cardano_builder_state_t* state,
+  cardano_coin_selector_t* coin_selector,
+  const char**             error_message)
+{
+  if (coin_selector == NULL)
+  {
+    *error_message = "Coin selector is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_coin_selector_ref(coin_selector);
+  cardano_coin_selector_unref(&state->coin_selector);
+  state->coin_selector = coin_selector;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_tx_evaluator(
+  cardano_builder_state_t* state,
+  cardano_tx_evaluator_t*  tx_evaluator,
+  const char**             error_message)
+{
+  if (tx_evaluator == NULL)
+  {
+    *error_message = "Transaction evaluator is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_tx_evaluator_ref(tx_evaluator);
+  cardano_tx_evaluator_unref(&state->tx_evaluator);
+  state->tx_evaluator = tx_evaluator;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_network_id(
+  cardano_builder_state_t*   state,
+  const cardano_network_id_t network_id,
+  const char**               error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_error_t result = cardano_transaction_body_set_network_id(body, &network_id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set network ID.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_change_address(
+  cardano_builder_state_t* state,
+  cardano_address_t*       change_address,
+  const char**             error_message)
+{
+  if (change_address == NULL)
+  {
+    *error_message = "Change address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_ref(change_address);
+  cardano_address_unref(&state->change_address);
+  state->change_address = change_address;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_change_address_ex(
+  cardano_builder_state_t* state,
+  const char*              change_address,
+  const size_t             address_size,
+  const char**             error_message)
+{
+  if ((change_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Change address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* address = NULL;
+  cardano_error_t    result  = cardano_address_from_string(change_address, address_size, &address);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse change address.";
+    return result;
+  }
+
+  result = cardano_builder_set_change_address(state, address, error_message);
+  cardano_address_unref(&address);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_collateral_change_address(
+  cardano_builder_state_t* state,
+  cardano_address_t*       collateral_change_address,
+  const char**             error_message)
+{
+  if (collateral_change_address == NULL)
+  {
+    *error_message = "Collateral change address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_ref(collateral_change_address);
+  cardano_address_unref(&state->collateral_address);
+  state->collateral_address = collateral_change_address;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_collateral_change_address_ex(
+  cardano_builder_state_t* state,
+  const char*              collateral_change_address,
+  const size_t             address_size,
+  const char**             error_message)
+{
+  if ((collateral_change_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Collateral change address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* address = NULL;
+  cardano_error_t    result  = cardano_address_from_string(collateral_change_address, address_size, &address);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse collateral change address.";
+    return result;
+  }
+
+  result = cardano_builder_set_collateral_change_address(state, address, error_message);
+  cardano_address_unref(&address);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_minimum_fee(
+  cardano_builder_state_t* state,
+  const uint64_t           minimum_fee,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_error_t result = cardano_transaction_body_set_fee(body, minimum_fee);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set fee.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_donation(
+  cardano_builder_state_t* state,
+  const uint64_t           donation,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_error_t result = CARDANO_SUCCESS;
+
+  if (donation == 0U)
+  {
+    result = cardano_transaction_body_set_donation(body, NULL);
+  }
+  else
+  {
+    result = cardano_transaction_body_set_donation(body, &donation);
+  }
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set donation.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_utxos(
+  cardano_builder_state_t* state,
+  cardano_utxo_list_t*     utxos,
+  const char**             error_message)
+{
+  if (utxos == NULL)
+  {
+    *error_message = "UTXOs list is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_utxo_list_ref(utxos);
+  cardano_utxo_list_unref(&state->available_utxos);
+  state->available_utxos = utxos;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_collateral_utxos(
+  cardano_builder_state_t* state,
+  cardano_utxo_list_t*     utxos,
+  const char**             error_message)
+{
+  if (utxos == NULL)
+  {
+    *error_message = "Collateral UTXOs list is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_utxo_list_ref(utxos);
+  cardano_utxo_list_unref(&state->collateral_utxos);
+  state->collateral_utxos = utxos;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_set_invalid_after(
+  cardano_builder_state_t* state,
+  const uint64_t           slot,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_error_t result = cardano_transaction_body_set_invalid_after(body, &slot);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set invalid after.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_invalid_after_ex(
+  cardano_builder_state_t* state,
+  const uint64_t           unix_time,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &state->slot_config);
+  cardano_error_t result = cardano_transaction_body_set_invalid_after(body, &slot);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set invalid after.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_invalid_before(
+  cardano_builder_state_t* state,
+  const uint64_t           slot,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_error_t result = cardano_transaction_body_set_invalid_before(body, &slot);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set invalid before.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_invalid_before_ex(
+  cardano_builder_state_t* state,
+  const uint64_t           unix_time,
+  const char**             error_message)
+{
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  if (body == NULL)
+  {
+    *error_message = "Transaction body is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &state->slot_config);
+  cardano_error_t result = cardano_transaction_body_set_invalid_before(body, &slot);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set invalid before.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_metadata(
+  cardano_builder_state_t* state,
+  const uint64_t           tag,
+  cardano_metadatum_t*     metadata,
+  const char**             error_message)
+{
+  if (metadata == NULL)
+  {
+    *error_message = "Metadata is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_auxiliary_data_t* auxiliary_data = cardano_transaction_get_auxiliary_data(state->transaction);
+
+  if (auxiliary_data == NULL)
+  {
+    cardano_error_t result = cardano_auxiliary_data_new(&auxiliary_data);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create auxiliary data.";
+      return result;
+    }
+
+    result = cardano_transaction_set_auxiliary_data(state->transaction, auxiliary_data);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set auxiliary data.";
+      cardano_auxiliary_data_unref(&auxiliary_data);
+      return result;
+    }
+  }
+
+  cardano_auxiliary_data_unref(&auxiliary_data);
+
+  cardano_transaction_metadata_t* tx_metadata = cardano_auxiliary_data_get_transaction_metadata(auxiliary_data);
+
+  if (tx_metadata == NULL)
+  {
+    cardano_error_t result = cardano_transaction_metadata_new(&tx_metadata);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create transaction metadata.";
+      return result;
+    }
+
+    result = cardano_auxiliary_data_set_transaction_metadata(auxiliary_data, tx_metadata);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set transaction metadata.";
+      cardano_transaction_metadata_unref(&tx_metadata);
+      return result;
+    }
+  }
+
+  cardano_transaction_metadata_unref(&tx_metadata);
+
+  cardano_error_t result = cardano_transaction_metadata_insert(tx_metadata, tag, metadata);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to insert metadata.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_blake2b_hash_t* hash = cardano_auxiliary_data_get_hash(auxiliary_data);
+
+  result = cardano_transaction_body_set_aux_data_hash(body, hash);
+  cardano_blake2b_hash_unref(&hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set auxiliary data hash.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_set_metadata_ex(
+  cardano_builder_state_t* state,
+  const uint64_t           tag,
+  const char*              metadata_json,
+  const size_t             json_size,
+  const char**             error_message)
+{
+  if ((metadata_json == NULL) || (json_size == 0U))
+  {
+    *error_message = "Metadata is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_metadatum_t* metadata = NULL;
+  cardano_error_t      result   = cardano_metadatum_from_json(metadata_json, json_size, &metadata);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse metadata.";
+    return result;
+  }
+
+  result = cardano_builder_set_metadata(state, tag, metadata, error_message);
+  cardano_metadatum_unref(&metadata);
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_config.h
+++ b/lib/src/transaction_builder/internals/builder_config.h
@@ -1,0 +1,432 @@
+/**
+ * \file builder_config.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CONFIG_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CONFIG_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/address.h>
+#include <cardano/auxiliary_data/metadatum.h>
+#include <cardano/common/network_id.h>
+#include <cardano/common/utxo_list.h>
+#include <cardano/error.h>
+#include <cardano/transaction_builder/coin_selection/coin_selector.h>
+#include <cardano/transaction_builder/evaluation/tx_evaluator.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Sets the coin selection strategy used during balancing.
+ *
+ * This function takes a reference on \p coin_selector and stores it in the state, releasing the
+ * previously configured coin selector.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] coin_selector A pointer to the \ref cardano_coin_selector_t to use. This parameter must
+ *                          not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the coin selector was set, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_coin_selector(
+  cardano_builder_state_t* state,
+  cardano_coin_selector_t* coin_selector,
+  const char**             error_message);
+
+/**
+ * \brief Sets the evaluator used to compute execution units for Plutus scripts.
+ *
+ * This function takes a reference on \p tx_evaluator and stores it in the state, releasing the
+ * previously configured transaction evaluator.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] tx_evaluator A pointer to the \ref cardano_tx_evaluator_t to use. This parameter must
+ *                         not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the transaction evaluator was set, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_tx_evaluator(
+  cardano_builder_state_t* state,
+  cardano_tx_evaluator_t*  tx_evaluator,
+  const char**             error_message);
+
+/**
+ * \brief Sets the network identifier in the transaction body.
+ *
+ * This function writes \p network_id into the body of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] network_id The \ref cardano_network_id_t to set.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the network identifier was set, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_network_id(
+  cardano_builder_state_t* state,
+  cardano_network_id_t     network_id,
+  const char**             error_message);
+
+/**
+ * \brief Sets the address that receives any change produced while balancing.
+ *
+ * This function takes a reference on \p change_address and stores it in the state, releasing the
+ * previously configured change address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] change_address A pointer to the \ref cardano_address_t to use. This parameter must not
+ *                           be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the change address was set, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_change_address(
+  cardano_builder_state_t* state,
+  cardano_address_t*       change_address,
+  const char**             error_message);
+
+/**
+ * \brief Sets the change address given its string representation.
+ *
+ * This function parses \p change_address and delegates to \ref cardano_builder_set_change_address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] change_address A pointer to the string with the change address.
+ * \param[in] address_size The size of the change address string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the change address was set, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_change_address_ex(
+  cardano_builder_state_t* state,
+  const char*              change_address,
+  size_t                   address_size,
+  const char**             error_message);
+
+/**
+ * \brief Sets the address that receives any collateral change output.
+ *
+ * This function takes a reference on \p collateral_change_address and stores it in the state,
+ * releasing the previously configured collateral change address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] collateral_change_address A pointer to the \ref cardano_address_t to use. This parameter
+ *                                      must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the collateral change address was set, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_collateral_change_address(
+  cardano_builder_state_t* state,
+  cardano_address_t*       collateral_change_address,
+  const char**             error_message);
+
+/**
+ * \brief Sets the collateral change address given its string representation.
+ *
+ * This function parses \p collateral_change_address and delegates to
+ * \ref cardano_builder_set_collateral_change_address.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] collateral_change_address A pointer to the string with the collateral change address.
+ * \param[in] address_size The size of the collateral change address string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the collateral change address was set, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_collateral_change_address_ex(
+  cardano_builder_state_t* state,
+  const char*              collateral_change_address,
+  size_t                   address_size,
+  const char**             error_message);
+
+/**
+ * \brief Sets the fee in the transaction body.
+ *
+ * This function writes \p minimum_fee as the fee of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] minimum_fee The fee in lovelace to set.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the fee was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_minimum_fee(
+  cardano_builder_state_t* state,
+  uint64_t                 minimum_fee,
+  const char**             error_message);
+
+/**
+ * \brief Sets the treasury donation in the transaction body.
+ *
+ * This function writes \p donation as the donation of the transaction under construction, removing
+ * any previously set donation when \p donation is zero.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] donation The donation in lovelace to set.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the donation was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_donation(
+  cardano_builder_state_t* state,
+  uint64_t                 donation,
+  const char**             error_message);
+
+/**
+ * \brief Sets the UTXO set available to the coin selector for input selection.
+ *
+ * This function takes a reference on \p utxos and stores it in the state, releasing the previously
+ * configured UTXO list.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] utxos A pointer to the \ref cardano_utxo_list_t to use. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the UTXO list was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_utxos(
+  cardano_builder_state_t* state,
+  cardano_utxo_list_t*     utxos,
+  const char**             error_message);
+
+/**
+ * \brief Sets the UTXO set available for collateral selection.
+ *
+ * This function takes a reference on \p utxos and stores it in the state, releasing the previously
+ * configured collateral UTXO list.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] utxos A pointer to the \ref cardano_utxo_list_t to use. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the collateral UTXO list was set, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_collateral_utxos(
+  cardano_builder_state_t* state,
+  cardano_utxo_list_t*     utxos,
+  const char**             error_message);
+
+/**
+ * \brief Sets the slot after which the transaction is invalid.
+ *
+ * This function writes \p slot as the invalid after bound of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] slot The slot number to set.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the bound was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_invalid_after(
+  cardano_builder_state_t* state,
+  uint64_t                 slot,
+  const char**             error_message);
+
+/**
+ * \brief Sets the slot after which the transaction is invalid given a Unix time.
+ *
+ * This function converts \p unix_time to the enclosing slot using the state slot configuration and
+ * writes it as the invalid after bound of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] unix_time The Unix time in seconds to convert.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the bound was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_invalid_after_ex(
+  cardano_builder_state_t* state,
+  uint64_t                 unix_time,
+  const char**             error_message);
+
+/**
+ * \brief Sets the slot before which the transaction is invalid.
+ *
+ * This function writes \p slot as the invalid before bound of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] slot The slot number to set.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the bound was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_invalid_before(
+  cardano_builder_state_t* state,
+  uint64_t                 slot,
+  const char**             error_message);
+
+/**
+ * \brief Sets the slot before which the transaction is invalid given a Unix time.
+ *
+ * This function converts \p unix_time to the enclosing slot using the state slot configuration and
+ * writes it as the invalid before bound of the transaction under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] unix_time The Unix time in seconds to convert.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the bound was set, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_set_invalid_before_ex(
+  cardano_builder_state_t* state,
+  uint64_t                 unix_time,
+  const char**             error_message);
+
+/**
+ * \brief Inserts a metadatum under a tag in the transaction metadata.
+ *
+ * This function inserts \p metadata under \p tag in the transaction metadata of the auxiliary data,
+ * creating the auxiliary data and the metadata map when they are missing, and refreshes the
+ * auxiliary data hash in the transaction body.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] tag The metadata label under which the metadatum is inserted.
+ * \param[in] metadata A pointer to the \ref cardano_metadatum_t to insert. This parameter must not
+ *                     be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the metadatum was inserted, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_metadata(
+  cardano_builder_state_t* state,
+  uint64_t                 tag,
+  cardano_metadatum_t*     metadata,
+  const char**             error_message);
+
+/**
+ * \brief Inserts a metadatum under a tag given its JSON representation.
+ *
+ * This function parses \p metadata_json into a metadatum and delegates to
+ * \ref cardano_builder_set_metadata.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] tag The metadata label under which the metadatum is inserted.
+ * \param[in] metadata_json A pointer to the JSON string with the metadatum.
+ * \param[in] json_size The size of the JSON string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the metadatum was inserted, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_set_metadata_ex(
+  cardano_builder_state_t* state,
+  uint64_t                 tag,
+  const char*              metadata_json,
+  size_t                   json_size,
+  const char**             error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_CONFIG_H

--- a/lib/src/transaction_builder/internals/builder_inputs.c
+++ b/lib/src/transaction_builder/internals/builder_inputs.c
@@ -1,0 +1,347 @@
+/**
+ * \file builder_inputs.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_inputs.h"
+
+#include <cardano/common/ex_units.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/transaction_body/transaction_input_set.h>
+#include <cardano/witness_set/redeemer_list.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "builder_redeemers.h"
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_add_input(
+  cardano_builder_state_t* state,
+  cardano_utxo_t*          utxo,
+  cardano_plutus_data_t*   redeemer,
+  cardano_plutus_data_t*   datum,
+  const char**             error_message)
+{
+  if (utxo == NULL)
+  {
+    *error_message = "UTXO is required";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_output_t* output = cardano_utxo_get_output(utxo);
+  cardano_transaction_output_unref(&output);
+
+  cardano_address_t* address = cardano_transaction_output_get_address(output);
+  cardano_address_unref(&address);
+
+  cardano_address_type_t address_type;
+
+  cardano_error_t result = cardano_address_get_type(address, &address_type);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to get address type";
+    return result;
+  }
+
+  result = cardano_utxo_list_add(state->pre_selected_inputs, utxo);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add UTXO to pre-selected inputs";
+
+    return result;
+  }
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witnesses);
+
+  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
+
+  if (redeemers == NULL)
+  {
+    result = cardano_redeemer_list_new(&redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create redeemers list";
+      return result;
+    }
+
+    result = cardano_witness_set_set_redeemers(witnesses, redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set redeemers list";
+      cardano_redeemer_list_unref(&redeemers);
+      return result;
+    }
+  }
+
+  cardano_redeemer_list_unref(&redeemers);
+
+  if (redeemer != NULL)
+  {
+    cardano_redeemer_t* rdmer = NULL;
+
+    cardano_ex_units_t* ex_units = NULL;
+    result                       = cardano_ex_units_new(0, 0, &ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create execution units";
+      return result;
+    }
+
+    result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_SPEND, 0, redeemer, ex_units, &rdmer);
+    cardano_ex_units_unref(&ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create redeemer";
+      return result;
+    }
+
+    result = cardano_redeemer_list_add(redeemers, rdmer);
+    cardano_redeemer_unref(&rdmer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add redeemer to list";
+      return result;
+    }
+
+    cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
+    cardano_transaction_input_unref(&input);
+
+    result = cardano_input_to_redeemer_map_insert(state->input_to_redeemer_map, input, rdmer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to insert input to redeemer map";
+      return result;
+    }
+  }
+
+  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witnesses);
+
+  if (datums == NULL)
+  {
+    result = cardano_plutus_data_set_new(&datums);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create datums set";
+      return result;
+    }
+
+    result = cardano_witness_set_set_plutus_data(witnesses, datums);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set datums set";
+      cardano_plutus_data_set_unref(&datums);
+      return result;
+    }
+  }
+
+  cardano_plutus_data_set_unref(&datums);
+
+  if (datum != NULL)
+  {
+    result = cardano_plutus_data_set_add(datums, datum);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add datum to set";
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_add_input_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_utxo_t*                utxo,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  cardano_plutus_data_t*         datum,
+  const char**                   error_message)
+{
+  if ((utxo == NULL) || (callback == NULL))
+  {
+    *error_message = "UTXO and callback are required";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_plutus_data_t* placeholder = NULL;
+
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create the placeholder redeemer.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_input(state, utxo, placeholder, datum, error_message);
+
+  cardano_plutus_data_unref(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
+  cardano_transaction_input_unref(&input);
+
+  cardano_redeemer_t* redeemer = NULL;
+
+  result = cardano_input_to_redeemer_map_get(state->input_to_redeemer_map, input, &redeemer);
+
+  if (result == CARDANO_SUCCESS)
+  {
+    result = cardano_deferred_redeemer_list_add(state->deferred_redeemers, redeemer, callback, user_context);
+  }
+
+  cardano_redeemer_unref(&redeemer);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to register the deferred redeemer.";
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_add_reference_input(
+  cardano_builder_state_t* state,
+  cardano_utxo_t*          utxo,
+  const char**             error_message)
+{
+  if (utxo == NULL)
+  {
+    *error_message = "UTXO is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_input_set_t* inputs = cardano_transaction_body_get_reference_inputs(body);
+
+  if (inputs == NULL)
+  {
+    cardano_error_t result = cardano_transaction_input_set_new(&inputs);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create reference inputs.";
+      return result;
+    }
+
+    result = cardano_transaction_body_set_reference_inputs(body, inputs);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set reference inputs.";
+      cardano_transaction_input_set_unref(&inputs);
+
+      return result;
+    }
+  }
+
+  cardano_transaction_input_set_unref(&inputs);
+
+  cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
+  cardano_transaction_input_unref(&input);
+
+  cardano_error_t result = cardano_transaction_input_set_add(inputs, input);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add input to reference inputs.";
+    return result;
+  }
+
+  cardano_transaction_output_t* output = cardano_utxo_get_output(utxo);
+  cardano_transaction_output_unref(&output);
+
+  if (output == NULL)
+  {
+    *error_message = "Output is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_script_t* script = cardano_transaction_output_get_script_ref(output);
+  cardano_script_unref(&script);
+
+  if (script != NULL)
+  {
+    cardano_script_language_t language;
+    result = cardano_script_get_language(script, &language);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to get script language.";
+      return result;
+    }
+
+    switch (language)
+    {
+      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
+      {
+        state->has_plutus_v1 = true;
+        break;
+      }
+      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
+      {
+        state->has_plutus_v2 = true;
+        break;
+      }
+      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
+      {
+        state->has_plutus_v3 = true;
+        break;
+      }
+      default:
+      {
+        break;
+      }
+    }
+  }
+
+  result = cardano_utxo_list_add(state->reference_inputs, utxo);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add UTXO to reference inputs.";
+  }
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_inputs.h
+++ b/lib/src/transaction_builder/internals/builder_inputs.h
@@ -1,0 +1,130 @@
+/**
+ * \file builder_inputs.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_INPUTS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_INPUTS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/common/utxo.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Adds a UTXO to the set of inputs the transaction must spend.
+ *
+ * This function appends the UTXO to the state pre selected input list so it is always included when
+ * the transaction is balanced. When \p redeemer is not NULL it creates a spend redeemer with a zero
+ * index and zero execution units, appends it to the witness set redeemer list and records it in the
+ * state input to redeemer map so its index can be resolved during balancing. When \p datum is not
+ * NULL it is added to the witness set plutus data set.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] utxo A pointer to the \ref cardano_utxo_t to spend. The list holds a reference to it.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as spend redeemer payload, or
+ *                     NULL when the input does not require a redeemer.
+ * \param[in] datum A pointer to the \ref cardano_plutus_data_t witness datum, or NULL when the input
+ *                  does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the input was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_input(
+  cardano_builder_state_t* state,
+  cardano_utxo_t*          utxo,
+  cardano_plutus_data_t*   redeemer,
+  cardano_plutus_data_t*   datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds a UTXO to spend whose redeemer payload is resolved during balancing.
+ *
+ * This function adds the UTXO as a pre selected input with an empty placeholder redeemer and
+ * registers the callback in the state deferred redeemer list. The callback is invoked while the
+ * transaction is balanced to produce the final redeemer payload.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] utxo A pointer to the \ref cardano_utxo_t to spend. This parameter must not be NULL.
+ * \param[in] callback The deferred redeemer callback invoked during balancing. This parameter must
+ *                     not be NULL.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[in] datum A pointer to the \ref cardano_plutus_data_t witness datum, or NULL when the input
+ *                  does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the input and callback were registered, or an appropriate error
+ *         code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_add_input_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_utxo_t*                utxo,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  cardano_plutus_data_t*         datum,
+  const char**                   error_message);
+
+/**
+ * \brief Adds a UTXO as a reference input of the transaction.
+ *
+ * This function appends the UTXO input to the transaction body reference input set, creating the set
+ * when it is missing, and records the UTXO in the state reference input list. When the UTXO output
+ * carries a Plutus script reference the matching script language flag is raised in the state so cost
+ * models and collateral are accounted for during balancing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] utxo A pointer to the \ref cardano_utxo_t to reference. The list holds a reference to it.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the reference input was added, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_add_reference_input(
+  cardano_builder_state_t* state,
+  cardano_utxo_t*          utxo,
+  const char**             error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_INPUTS_H

--- a/lib/src/transaction_builder/internals/builder_mint.c
+++ b/lib/src/transaction_builder/internals/builder_mint.c
@@ -1,0 +1,272 @@
+/**
+ * \file builder_mint.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_mint.h"
+
+#include <cardano/assets/multi_asset.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "builder_redeemers.h"
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_mint_token(
+  cardano_builder_state_t* state,
+  cardano_blake2b_hash_t*  policy_id,
+  cardano_asset_name_t*    name,
+  const int64_t            amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (policy_id == NULL)
+  {
+    *error_message = "Policy ID is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (name == NULL)
+  {
+    *error_message = "Asset name is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_multi_asset_t* tokens = cardano_transaction_body_get_mint(body);
+
+  if (tokens == NULL)
+  {
+    cardano_error_t result = cardano_multi_asset_new(&tokens);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create multi-asset.";
+
+      return result;
+    }
+
+    result = cardano_transaction_body_set_mint(body, tokens);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set multi-asset.";
+      cardano_multi_asset_unref(&tokens);
+
+      return result;
+    }
+  }
+
+  cardano_multi_asset_unref(&tokens);
+
+  cardano_error_t result = cardano_multi_asset_set(tokens, policy_id, name, amount);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set multi-asset.";
+
+    return result;
+  }
+
+  if (redeemer != NULL)
+  {
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+    cardano_witness_set_unref(&witnesses);
+
+    result = cardano_builder_add_redeemer(witnesses, policy_id, redeemer, CARDANO_REDEEMER_TAG_MINT, state, error_message);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add redeemer.";
+
+      return result;
+    }
+  }
+  else
+  {
+    result = cardano_blake2b_hash_to_redeemer_map_insert(state->mints_to_redeemer_map, policy_id, NULL);
+
+    if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+    {
+      *error_message = "Failed to add mint.";
+
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_mint_token_ex(
+  cardano_builder_state_t* state,
+  const char*              policy_id_hex,
+  size_t                   policy_id_size,
+  const char*              name_hex,
+  size_t                   name_size,
+  const int64_t            amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((policy_id_hex == NULL) || (policy_id_size == 0U))
+  {
+    *error_message = "Policy ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((name_hex == NULL) || (name_size == 0U))
+  {
+    *error_message = "Asset name is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_blake2b_hash_t* policy_id = NULL;
+  cardano_error_t         result    = cardano_blake2b_hash_from_hex(policy_id_hex, policy_id_size, &policy_id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse policy ID.";
+
+    return result;
+  }
+
+  cardano_asset_name_t* name = NULL;
+  result                     = cardano_asset_name_from_hex(name_hex, name_size, &name);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_blake2b_hash_unref(&policy_id);
+    *error_message = "Failed to parse asset name.";
+
+    return result;
+  }
+
+  result = cardano_builder_mint_token(state, policy_id, name, amount, redeemer, error_message);
+
+  cardano_blake2b_hash_unref(&policy_id);
+  cardano_asset_name_unref(&name);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_mint_token_with_id(
+  cardano_builder_state_t* state,
+  cardano_asset_id_t*      asset_id,
+  const int64_t            amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if (asset_id == NULL)
+  {
+    *error_message = "Asset ID is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_blake2b_hash_t* policy_id = cardano_asset_id_get_policy_id(asset_id);
+  cardano_asset_name_t*   name      = cardano_asset_id_get_asset_name(asset_id);
+
+  cardano_blake2b_hash_unref(&policy_id);
+  cardano_asset_name_unref(&name);
+
+  return cardano_builder_mint_token(state, policy_id, name, amount, redeemer, error_message);
+}
+
+cardano_error_t
+cardano_builder_mint_token_with_id_ex(
+  cardano_builder_state_t* state,
+  const char*              asset_id_hex,
+  size_t                   hex_size,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((asset_id_hex == NULL) || (hex_size == 0U))
+  {
+    *error_message = "Asset ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_asset_id_t* asset_id = NULL;
+  cardano_error_t     result   = cardano_asset_id_from_hex(asset_id_hex, hex_size, &asset_id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse asset ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_mint_token_with_id(state, asset_id, amount, redeemer, error_message);
+  cardano_asset_id_unref(&asset_id);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_mint_token_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_blake2b_hash_t*        policy_id,
+  cardano_asset_name_t*          name,
+  const int64_t                  amount,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message)
+{
+  if ((policy_id == NULL) || (callback == NULL))
+  {
+    *error_message = "Policy id and callback are required";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_plutus_data_t* placeholder = NULL;
+
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create the placeholder redeemer.";
+
+    return result;
+  }
+
+  result = cardano_builder_mint_token(state, policy_id, name, amount, placeholder, error_message);
+
+  cardano_plutus_data_unref(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  return cardano_builder_register_deferred_from_map(state, state->mints_to_redeemer_map, policy_id, callback, user_context, error_message);
+}

--- a/lib/src/transaction_builder/internals/builder_mint.h
+++ b/lib/src/transaction_builder/internals/builder_mint.h
@@ -1,0 +1,203 @@
+/**
+ * \file builder_mint.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_MINT_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_MINT_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/assets/asset_id.h>
+#include <cardano/assets/asset_name.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Records a token mint or burn in the transaction.
+ *
+ * This function sets the amount for the asset identified by \p policy_id and \p name in the mint
+ * field of the transaction body, creating the mint multi asset when it is missing. When \p redeemer
+ * is not NULL it is attached as a mint redeemer keyed by the policy in the state mint redeemer map.
+ * When \p redeemer is NULL the policy is still recorded in the map with a NULL redeemer so redeemer
+ * indices can be computed, and an already recorded policy is tolerated.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] policy_id A pointer to the \ref cardano_blake2b_hash_t with the minting policy hash.
+ *                      This parameter must not be NULL.
+ * \param[in] name A pointer to the \ref cardano_asset_name_t of the token. This parameter must not
+ *                 be NULL.
+ * \param[in] amount The amount to mint when positive or burn when negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as mint redeemer payload, or
+ *                     NULL when the policy does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the mint was recorded, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_mint_token(
+  cardano_builder_state_t* state,
+  cardano_blake2b_hash_t*  policy_id,
+  cardano_asset_name_t*    name,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Records a token mint or burn given the policy hash and asset name as hexadecimal strings.
+ *
+ * This function parses the policy hash and asset name and delegates to
+ * \ref cardano_builder_mint_token.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] policy_id_hex A pointer to the hexadecimal string with the minting policy hash.
+ * \param[in] policy_id_size The size of the policy hash string in bytes.
+ * \param[in] name_hex A pointer to the hexadecimal string with the asset name.
+ * \param[in] name_size The size of the asset name string in bytes.
+ * \param[in] amount The amount to mint when positive or burn when negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as mint redeemer payload, or
+ *                     NULL when the policy does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the mint was recorded, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_mint_token_ex(
+  cardano_builder_state_t* state,
+  const char*              policy_id_hex,
+  size_t                   policy_id_size,
+  const char*              name_hex,
+  size_t                   name_size,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Records a token mint or burn given a fully formed asset id.
+ *
+ * This function extracts the policy hash and asset name from \p asset_id and delegates to
+ * \ref cardano_builder_mint_token.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] asset_id A pointer to the \ref cardano_asset_id_t identifying the token. This parameter
+ *                     must not be NULL.
+ * \param[in] amount The amount to mint when positive or burn when negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as mint redeemer payload, or
+ *                     NULL when the policy does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the mint was recorded, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_mint_token_with_id(
+  cardano_builder_state_t* state,
+  cardano_asset_id_t*      asset_id,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Records a token mint or burn given an asset id as a hexadecimal string.
+ *
+ * This function parses the asset id and delegates to \ref cardano_builder_mint_token_with_id.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] asset_id_hex A pointer to the hexadecimal string with the asset id.
+ * \param[in] hex_size The size of the asset id string in bytes.
+ * \param[in] amount The amount to mint when positive or burn when negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as mint redeemer payload, or
+ *                     NULL when the policy does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the mint was recorded, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_mint_token_with_id_ex(
+  cardano_builder_state_t* state,
+  const char*              asset_id_hex,
+  size_t                   hex_size,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Records a token mint or burn whose redeemer payload is resolved during balancing.
+ *
+ * This function records the mint with an empty placeholder redeemer and registers the callback in
+ * the state deferred redeemer list. The callback is invoked while the transaction is balanced to
+ * produce the final redeemer payload.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] policy_id A pointer to the \ref cardano_blake2b_hash_t with the minting policy hash.
+ *                      This parameter must not be NULL.
+ * \param[in] name A pointer to the \ref cardano_asset_name_t of the token. This parameter must not
+ *                 be NULL.
+ * \param[in] amount The amount to mint when positive or burn when negative.
+ * \param[in] callback The deferred redeemer callback invoked during balancing. This parameter must
+ *                     not be NULL.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the mint and callback were registered, or an appropriate error
+ *         code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_mint_token_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_blake2b_hash_t*        policy_id,
+  cardano_asset_name_t*          name,
+  int64_t                        amount,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_MINT_H

--- a/lib/src/transaction_builder/internals/builder_outputs.c
+++ b/lib/src/transaction_builder/internals/builder_outputs.c
@@ -1,0 +1,384 @@
+/**
+ * \file builder_outputs.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_outputs.h"
+
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/transaction_body/transaction_output_list.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_send_lovelace(
+  cardano_builder_state_t* state,
+  cardano_address_t*       address,
+  const uint64_t           amount,
+  const char**             error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_output_t* output = NULL;
+  cardano_error_t               result = cardano_transaction_output_new(address, amount, &output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create output.";
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
+  cardano_transaction_output_list_unref(&outputs);
+
+  result = cardano_transaction_output_list_add(outputs, output);
+  cardano_transaction_output_unref(&output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add output to transaction.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_send_lovelace_ex(
+  cardano_builder_state_t* state,
+  const char*              address,
+  size_t                   address_size,
+  uint64_t                 amount,
+  const char**             error_message)
+{
+  if ((address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* addr   = NULL;
+  cardano_error_t    result = cardano_address_from_string(address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse address.";
+    return result;
+  }
+
+  result = cardano_builder_send_lovelace(state, addr, amount, error_message);
+  cardano_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_send_value(
+  cardano_builder_state_t* state,
+  cardano_address_t*       address,
+  cardano_value_t*         value,
+  const char**             error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (value == NULL)
+  {
+    *error_message = "Value is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_output_t* output = NULL;
+  cardano_error_t               result = cardano_transaction_output_new(address, 0U, &output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create output.";
+    return result;
+  }
+
+  result = cardano_transaction_output_set_value(output, value);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set value.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
+  cardano_transaction_output_list_unref(&outputs);
+
+  result = cardano_transaction_output_list_add(outputs, output);
+  cardano_transaction_output_unref(&output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add output to transaction.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_send_value_ex(
+  cardano_builder_state_t* state,
+  const char*              address,
+  size_t                   address_size,
+  cardano_value_t*         value,
+  const char**             error_message)
+{
+  if ((address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (value == NULL)
+  {
+    *error_message = "Value is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* addr   = NULL;
+  cardano_error_t    result = cardano_address_from_string(address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse address.";
+    return result;
+  }
+
+  result = cardano_builder_send_value(state, addr, value, error_message);
+  cardano_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_lock_lovelace(
+  cardano_builder_state_t* state,
+  cardano_address_t*       script_address,
+  const uint64_t           amount,
+  cardano_datum_t*         datum,
+  const char**             error_message)
+{
+  if (script_address == NULL)
+  {
+    *error_message = "Script address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_output_t* output = NULL;
+  cardano_error_t               result = cardano_transaction_output_new(script_address, amount, &output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create output.";
+    return result;
+  }
+
+  result = cardano_transaction_output_set_datum(output, datum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set datum.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
+  cardano_transaction_output_list_unref(&outputs);
+
+  result = cardano_transaction_output_list_add(outputs, output);
+  cardano_transaction_output_unref(&output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add output to transaction.";
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_lock_lovelace_ex(
+  cardano_builder_state_t* state,
+  const char*              script_address,
+  size_t                   script_address_size,
+  uint64_t                 amount,
+  cardano_datum_t*         datum,
+  const char**             error_message)
+{
+  if ((script_address == NULL) || (script_address_size == 0U))
+  {
+    *error_message = "Script address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* addr   = NULL;
+  cardano_error_t    result = cardano_address_from_string(script_address, script_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse script address.";
+    return result;
+  }
+
+  result = cardano_builder_lock_lovelace(state, addr, amount, datum, error_message);
+  cardano_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_lock_value(
+  cardano_builder_state_t* state,
+  cardano_address_t*       script_address,
+  cardano_value_t*         value,
+  cardano_datum_t*         datum,
+  const char**             error_message)
+{
+  if (script_address == NULL)
+  {
+    *error_message = "Script address is NULL.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_output_t* output = NULL;
+  cardano_error_t               result = cardano_transaction_output_new(script_address, 0U, &output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create output.";
+    return result;
+  }
+
+  result = cardano_transaction_output_set_value(output, value);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set value.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  result = cardano_transaction_output_set_datum(output, datum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to set datum.";
+    cardano_transaction_output_unref(&output);
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
+  cardano_transaction_output_list_unref(&outputs);
+
+  result = cardano_transaction_output_list_add(outputs, output);
+  cardano_transaction_output_unref(&output);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add output to transaction.";
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_lock_value_ex(
+  cardano_builder_state_t* state,
+  const char*              script_address,
+  size_t                   script_address_size,
+  cardano_value_t*         value,
+  cardano_datum_t*         datum,
+  const char**             error_message)
+{
+  if ((script_address == NULL) || (script_address_size == 0U))
+  {
+    *error_message = "Script address is NULL or empty.";
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_address_t* addr   = NULL;
+  cardano_error_t    result = cardano_address_from_string(script_address, script_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse script address.";
+    return result;
+  }
+
+  result = cardano_builder_lock_value(state, addr, value, datum, error_message);
+  cardano_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_add_output(
+  cardano_builder_state_t*      state,
+  cardano_transaction_output_t* output)
+{
+  if (output == NULL)
+  {
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
+  cardano_transaction_output_list_unref(&outputs);
+
+  return cardano_transaction_output_list_add(outputs, output);
+}

--- a/lib/src/transaction_builder/internals/builder_outputs.h
+++ b/lib/src/transaction_builder/internals/builder_outputs.h
@@ -1,0 +1,277 @@
+/**
+ * \file builder_outputs.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_OUTPUTS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_OUTPUTS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/address.h>
+#include <cardano/common/datum.h>
+#include <cardano/error.h>
+#include <cardano/transaction_body/transaction_output.h>
+#include <cardano/transaction_body/value.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Adds an output that sends the given amount of lovelace to an address.
+ *
+ * This function creates a transaction output paying \p amount lovelace to \p address and appends it
+ * to the output list of the transaction body under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_address_t receiving the lovelace. The output holds
+ *                    a reference to it.
+ * \param[in] amount The amount of lovelace to send.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_send_lovelace(
+  cardano_builder_state_t* state,
+  cardano_address_t*       address,
+  uint64_t                 amount,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that sends the given amount of lovelace to an address given as a string.
+ *
+ * This function parses the address string and delegates to \ref cardano_builder_send_lovelace.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the character string with the destination address.
+ * \param[in] address_size The size of the address string in bytes.
+ * \param[in] amount The amount of lovelace to send.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_send_lovelace_ex(
+  cardano_builder_state_t* state,
+  const char*              address,
+  size_t                   address_size,
+  uint64_t                 amount,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that sends the given value to an address.
+ *
+ * This function creates a transaction output carrying \p value (lovelace and native assets) for
+ * \p address and appends it to the output list of the transaction body under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_address_t receiving the value. The output holds a
+ *                    reference to it.
+ * \param[in] value A pointer to the \ref cardano_value_t to send. The output holds a reference to it.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_send_value(
+  cardano_builder_state_t* state,
+  cardano_address_t*       address,
+  cardano_value_t*         value,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that sends the given value to an address given as a string.
+ *
+ * This function parses the address string and delegates to \ref cardano_builder_send_value.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the character string with the destination address.
+ * \param[in] address_size The size of the address string in bytes.
+ * \param[in] value A pointer to the \ref cardano_value_t to send. The output holds a reference to it.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_send_value_ex(
+  cardano_builder_state_t* state,
+  const char*              address,
+  size_t                   address_size,
+  cardano_value_t*         value,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that locks the given amount of lovelace at a script address.
+ *
+ * This function creates a transaction output paying \p amount lovelace to \p script_address, attaches
+ * the optional datum and appends it to the output list of the transaction body under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] script_address A pointer to the \ref cardano_address_t of the script. The output holds a
+ *                           reference to it.
+ * \param[in] amount The amount of lovelace to lock.
+ * \param[in] datum A pointer to the \ref cardano_datum_t attached to the output, or NULL when the
+ *                  output carries no datum.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_lock_lovelace(
+  cardano_builder_state_t* state,
+  cardano_address_t*       script_address,
+  uint64_t                 amount,
+  cardano_datum_t*         datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that locks the given amount of lovelace at a script address given as a string.
+ *
+ * This function parses the script address string and delegates to \ref cardano_builder_lock_lovelace.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] script_address A pointer to the character string with the script address.
+ * \param[in] script_address_size The size of the script address string in bytes.
+ * \param[in] amount The amount of lovelace to lock.
+ * \param[in] datum A pointer to the \ref cardano_datum_t attached to the output, or NULL when the
+ *                  output carries no datum.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_lock_lovelace_ex(
+  cardano_builder_state_t* state,
+  const char*              script_address,
+  size_t                   script_address_size,
+  uint64_t                 amount,
+  cardano_datum_t*         datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that locks the given value at a script address.
+ *
+ * This function creates a transaction output carrying \p value (lovelace and native assets) for
+ * \p script_address, attaches the optional datum and appends it to the output list of the transaction
+ * body under construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] script_address A pointer to the \ref cardano_address_t of the script. The output holds a
+ *                           reference to it.
+ * \param[in] value A pointer to the \ref cardano_value_t to lock. The output holds a reference to it.
+ * \param[in] datum A pointer to the \ref cardano_datum_t attached to the output, or NULL when the
+ *                  output carries no datum.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_lock_value(
+  cardano_builder_state_t* state,
+  cardano_address_t*       script_address,
+  cardano_value_t*         value,
+  cardano_datum_t*         datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds an output that locks the given value at a script address given as a string.
+ *
+ * This function parses the script address string and delegates to \ref cardano_builder_lock_value.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] script_address A pointer to the character string with the script address.
+ * \param[in] script_address_size The size of the script address string in bytes.
+ * \param[in] value A pointer to the \ref cardano_value_t to lock. The output holds a reference to it.
+ * \param[in] datum A pointer to the \ref cardano_datum_t attached to the output, or NULL when the
+ *                  output carries no datum.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_lock_value_ex(
+  cardano_builder_state_t* state,
+  const char*              script_address,
+  size_t                   script_address_size,
+  cardano_value_t*         value,
+  cardano_datum_t*         datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds a fully formed output to the transaction.
+ *
+ * This function appends the given output to the output list of the transaction body under
+ * construction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] output A pointer to the \ref cardano_transaction_output_t to add. The list holds a
+ *                   reference to it.
+ *
+ * \return \ref CARDANO_SUCCESS if the output was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_output(
+  cardano_builder_state_t*      state,
+  cardano_transaction_output_t* output);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_OUTPUTS_H

--- a/lib/src/transaction_builder/internals/builder_proposals.c
+++ b/lib/src/transaction_builder/internals/builder_proposals.c
@@ -1,0 +1,1197 @@
+/**
+ * \file builder_proposals.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_proposals.h"
+
+#include <cardano/proposal_procedures/hard_fork_initiation_action.h>
+#include <cardano/proposal_procedures/info_action.h>
+#include <cardano/proposal_procedures/new_constitution_action.h>
+#include <cardano/proposal_procedures/no_confidence_action.h>
+#include <cardano/proposal_procedures/parameter_change_action.h>
+#include <cardano/proposal_procedures/proposal_procedure.h>
+#include <cardano/proposal_procedures/proposal_procedure_set.h>
+#include <cardano/proposal_procedures/treasury_withdrawals_action.h>
+#include <cardano/proposal_procedures/update_committee_action.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/witness_set/redeemer.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "../../string_safe.h"
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Gets the proposal procedures set from the transaction body. If there are no proposal
+ * procedures set, it creates a new list.
+ *
+ * \param body The transaction body.
+ *
+ * \return The proposal procedures set, or NULL when it could not be created or attached.
+ */
+static cardano_proposal_procedure_set_t*
+get_proposal_procedure_set(cardano_transaction_body_t* body)
+{
+  cardano_proposal_procedure_set_t* proposals = cardano_transaction_body_get_proposal_procedures(body);
+
+  if (proposals == NULL)
+  {
+    cardano_error_t result = cardano_proposal_procedure_set_new(&proposals);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return NULL;
+    }
+
+    result = cardano_transaction_body_set_proposal_procedure(body, proposals);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      cardano_proposal_procedure_set_unref(&proposals);
+
+      return NULL;
+    }
+  }
+
+  cardano_proposal_procedure_set_unref(&proposals);
+
+  return proposals;
+}
+
+/**
+ * \brief Creates an empty plutus data object.
+ *
+ * \return The empty plutus data object.
+ */
+static cardano_plutus_data_t*
+create_empty_plutus_data(void)
+{
+  static const char* VOID_DATA = "d87980";
+
+  cardano_plutus_data_t* plutus_data = NULL;
+  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex(VOID_DATA, cardano_safe_strlen(VOID_DATA, 6));
+
+  cardano_error_t result = cardano_plutus_data_from_cbor(reader, &plutus_data);
+  cardano_cbor_reader_unref(&reader);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return NULL;
+  }
+
+  return plutus_data;
+}
+
+/**
+ * \brief Adds an empty proposing redeemer to the witness set.
+ *
+ * \param witness_set The witness set.
+ * \param proposal_index The index of the proposal that requires the redeemer.
+ *
+ * \return The result of the operation.
+ */
+static cardano_error_t
+add_proposing_redeemer(
+  cardano_witness_set_t* witness_set,
+  const size_t           proposal_index)
+{
+  cardano_redeemer_list_t* redeemers         = cardano_witness_set_get_redeemers(witness_set);
+  cardano_plutus_data_t*   empty_plutus_data = create_empty_plutus_data();
+  cardano_redeemer_t*      rdmer             = NULL;
+  cardano_ex_units_t*      ex_units          = NULL;
+
+  cardano_error_t result = cardano_ex_units_new(0, 0, &ex_units);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_plutus_data_unref(&empty_plutus_data);
+    return result;
+  }
+
+  result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_PROPOSING, proposal_index, empty_plutus_data, ex_units, &rdmer);
+
+  cardano_plutus_data_unref(&empty_plutus_data);
+  cardano_ex_units_unref(&ex_units);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  if (redeemers == NULL)
+  {
+    result = cardano_redeemer_list_new(&redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      cardano_redeemer_unref(&rdmer);
+
+      return result;
+    }
+
+    result = cardano_witness_set_set_redeemers(witness_set, redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      cardano_redeemer_unref(&rdmer);
+      cardano_redeemer_list_unref(&redeemers);
+
+      return result;
+    }
+  }
+
+  cardano_redeemer_list_unref(&redeemers);
+
+  result = cardano_redeemer_list_add(redeemers, rdmer);
+  cardano_redeemer_unref(&rdmer);
+
+  return result;
+}
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_propose_parameter_change(
+  cardano_builder_state_t*         state,
+  cardano_reward_address_t*        reward_address,
+  cardano_anchor_t*                anchor,
+  cardano_protocol_param_update_t* protocol_param_update,
+  cardano_governance_action_id_t*  governance_action_id,
+  cardano_blake2b_hash_t*          policy_hash,
+  const char**                     error_message)
+{
+  if (policy_hash == NULL)
+  {
+    *error_message = "Policy hash is NULL. You must provide the constitution script hash.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_parameter_change_action_t* action = NULL;
+  cardano_error_t                    result = cardano_parameter_change_action_new(protocol_param_update, governance_action_id, policy_hash, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create parameter change action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_parameter_change_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_parameter_change_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+  }
+
+  cardano_proposal_procedure_unref(&proposal);
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witnesses);
+  const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
+
+  const cardano_error_t redeemer_result = add_proposing_redeemer(witnesses, proposal_index);
+
+  if (redeemer_result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposing redeemer.";
+    result         = redeemer_result;
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_parameter_change_ex(
+  cardano_builder_state_t*         state,
+  const char*                      reward_address,
+  const size_t                     reward_address_size,
+  const char*                      metadata_url,
+  const size_t                     metadata_url_size,
+  const char*                      metadata_hash_hex,
+  const size_t                     metadata_hash_hex_size,
+  const char*                      gov_action_id,
+  const size_t                     gov_action_id_size,
+  const char*                      policy_hash_hash_hex,
+  const size_t                     policy_hash_hash_hex_size,
+  cardano_protocol_param_update_t* protocol_param_update,
+  const char**                     error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
+  {
+    *error_message = "Governance action ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((policy_hash_hash_hex == NULL) || (policy_hash_hash_hex_size == 0U))
+  {
+    *error_message = "Policy hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_governance_action_id_t* id = NULL;
+
+  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse governance action ID.";
+
+    return result;
+  }
+
+  cardano_blake2b_hash_t* policy_hash = NULL;
+
+  result = cardano_blake2b_hash_from_hex(policy_hash_hash_hex, policy_hash_hash_hex_size, &policy_hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    cardano_governance_action_id_unref(&id);
+    *error_message = "Failed to parse policy hash.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_parameter_change(state, addr, anchor, protocol_param_update, id, policy_hash, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_governance_action_id_unref(&id);
+  cardano_blake2b_hash_unref(&policy_hash);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_hardfork(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_protocol_version_t*     version,
+  cardano_governance_action_id_t* governance_action_id,
+  const char**                    error_message)
+{
+  cardano_hard_fork_initiation_action_t* action = NULL;
+  cardano_error_t                        result = cardano_hard_fork_initiation_action_new(version, governance_action_id, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create hard fork action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_hard_fork_initiation_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_hard_fork_initiation_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_propose_hardfork_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  const size_t             reward_address_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  const char*              gov_action_id,
+  const size_t             gov_action_id_size,
+  const uint64_t           minor_protocol_version,
+  const uint64_t           major_protocol_version,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
+  {
+    *error_message = "Governance action ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_governance_action_id_t* id = NULL;
+
+  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse governance action ID.";
+
+    return result;
+  }
+
+  cardano_protocol_version_t* version = NULL;
+  result                              = cardano_protocol_version_new(minor_protocol_version, major_protocol_version, &version);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    cardano_governance_action_id_unref(&id);
+    *error_message = "Failed to create protocol version.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_hardfork(state, addr, anchor, version, id, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_governance_action_id_unref(&id);
+  cardano_protocol_version_unref(&version);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_treasury_withdrawals(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* reward_address,
+  cardano_anchor_t*         anchor,
+  cardano_withdrawal_map_t* withdrawals,
+  cardano_blake2b_hash_t*   policy_hash,
+  const char**              error_message)
+{
+  if (policy_hash == NULL)
+  {
+    *error_message = "Policy hash is NULL. You must provide the constitution script hash.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_treasury_withdrawals_action_t* action = NULL;
+  cardano_error_t                        result = cardano_treasury_withdrawals_action_new(withdrawals, policy_hash, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create treasury withdrawal action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_treasury_withdrawals_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_treasury_withdrawals_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+  }
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witnesses);
+  const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
+
+  const cardano_error_t redeemer_result = add_proposing_redeemer(witnesses, proposal_index);
+
+  if (redeemer_result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposing redeemer.";
+    result         = redeemer_result;
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_treasury_withdrawals_ex(
+  cardano_builder_state_t*  state,
+  const char*               reward_address,
+  const size_t              reward_address_size,
+  const char*               metadata_url,
+  const size_t              metadata_url_size,
+  const char*               metadata_hash_hex,
+  const size_t              metadata_hash_hex_size,
+  const char*               policy_hash_hash_hex,
+  const size_t              policy_hash_hash_hex_size,
+  cardano_withdrawal_map_t* withdrawals,
+  const char**              error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((policy_hash_hash_hex == NULL) || (policy_hash_hash_hex_size == 0U))
+  {
+    *error_message = "Policy hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_blake2b_hash_t* policy_hash = NULL;
+  result                              = cardano_blake2b_hash_from_hex(policy_hash_hash_hex, policy_hash_hash_hex_size, &policy_hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse policy hash.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_treasury_withdrawals(state, addr, anchor, withdrawals, policy_hash, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_blake2b_hash_unref(&policy_hash);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_no_confidence(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_governance_action_id_t* governance_action_id,
+  const char**                    error_message)
+{
+  cardano_no_confidence_action_t* action = NULL;
+  cardano_error_t                 result = cardano_no_confidence_action_new(governance_action_id, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create no confidence action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_no_confidence_action(deposit, reward_address, anchor, action, &proposal);
+  cardano_no_confidence_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_propose_no_confidence_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  const size_t             reward_address_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  const char*              gov_action_id,
+  const size_t             gov_action_id_size,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
+  {
+    *error_message = "Governance action ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_governance_action_id_t* id = NULL;
+
+  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse governance action ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_no_confidence(state, addr, anchor, id, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_governance_action_id_unref(&id);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_update_committee(
+  cardano_builder_state_t*         state,
+  cardano_reward_address_t*        reward_address,
+  cardano_anchor_t*                anchor,
+  cardano_governance_action_id_t*  governance_action_id,
+  cardano_credential_set_t*        members_to_be_removed,
+  cardano_committee_members_map_t* members_to_be_added,
+  cardano_unit_interval_t*         new_quorum,
+  const char**                     error_message)
+{
+  cardano_update_committee_action_t* action = NULL;
+  cardano_error_t                    result = cardano_update_committee_action_new(members_to_be_removed, members_to_be_added, new_quorum, governance_action_id, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create update committee action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+
+  const uint64_t deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_update_committee_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_update_committee_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_propose_update_committee_ex(
+  cardano_builder_state_t*         state,
+  const char*                      reward_address,
+  const size_t                     reward_address_size,
+  const char*                      metadata_url,
+  const size_t                     metadata_url_size,
+  const char*                      metadata_hash_hex,
+  const size_t                     metadata_hash_hex_size,
+  const char*                      gov_action_id,
+  const size_t                     gov_action_id_size,
+  cardano_credential_set_t*        members_to_be_removed,
+  cardano_committee_members_map_t* members_to_be_added,
+  const double                     new_quorum,
+  const char**                     error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
+  {
+    *error_message = "Governance action ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_governance_action_id_t* id = NULL;
+
+  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse governance action ID.";
+
+    return result;
+  }
+
+  cardano_unit_interval_t* quorum = NULL;
+  result                          = cardano_unit_interval_from_double(new_quorum, &quorum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    cardano_governance_action_id_unref(&id);
+    *error_message = "Failed to create unit interval.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_update_committee(state, addr, anchor, id, members_to_be_removed, members_to_be_added, quorum, error_message);
+
+  cardano_unit_interval_unref(&quorum);
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_governance_action_id_unref(&id);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_new_constitution(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_governance_action_id_t* governance_action_id,
+  cardano_constitution_t*         constitution,
+  const char**                    error_message)
+{
+  cardano_new_constitution_action_t* action = NULL;
+
+  cardano_error_t result = cardano_new_constitution_action_new(constitution, governance_action_id, &action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create new constitution action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_constitution_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_new_constitution_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_propose_new_constitution_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  const size_t             reward_address_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  const char*              gov_action_id,
+  const size_t             gov_action_id_size,
+  cardano_constitution_t*  constitution,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
+  {
+    *error_message = "Governance action ID is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+
+  result = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  cardano_governance_action_id_t* id = NULL;
+
+  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    cardano_reward_address_unref(&addr);
+    *error_message = "Failed to parse governance action ID.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_new_constitution(state, addr, anchor, id, constitution, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+  cardano_governance_action_id_unref(&id);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_propose_info(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* reward_address,
+  cardano_anchor_t*         anchor,
+  const char**              error_message)
+{
+  cardano_info_action_t* action = NULL;
+  cardano_error_t        result = cardano_info_action_new(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create info action.";
+
+    return result;
+  }
+
+  cardano_proposal_procedure_t* proposal;
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(state->params);
+
+  result = cardano_proposal_procedure_new_info_action(deposit, reward_address, anchor, action, &proposal);
+
+  cardano_info_action_unref(&action);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create proposal procedure.";
+
+    return result;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(body);
+
+  result = cardano_proposal_procedure_set_add(proposals, proposal);
+
+  cardano_proposal_procedure_unref(&proposal);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add proposal procedure.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_propose_info_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  const size_t             reward_address_size,
+  const char*              metadata_url,
+  const size_t             metadata_url_size,
+  const char*              metadata_hash_hex,
+  const size_t             metadata_hash_hex_size,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (reward_address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_url == NULL) || (metadata_url_size == 0U))
+  {
+    *error_message = "Metadata URL is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
+  {
+    *error_message = "Metadata hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_anchor_t* anchor = NULL;
+
+  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create anchor.";
+
+    return result;
+  }
+
+  cardano_reward_address_t* addr = NULL;
+
+  result = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_anchor_unref(&anchor);
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  result = cardano_builder_propose_info(state, addr, anchor, error_message);
+
+  cardano_anchor_unref(&anchor);
+  cardano_reward_address_unref(&addr);
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_proposals.h
+++ b/lib/src/transaction_builder/internals/builder_proposals.h
@@ -1,0 +1,569 @@
+/**
+ * \file builder_proposals.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_PROPOSALS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_PROPOSALS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/reward_address.h>
+#include <cardano/common/anchor.h>
+#include <cardano/common/governance_action_id.h>
+#include <cardano/common/protocol_version.h>
+#include <cardano/common/unit_interval.h>
+#include <cardano/common/withdrawal_map.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/proposal_procedures/committee_members_map.h>
+#include <cardano/proposal_procedures/constitution.h>
+#include <cardano/proposal_procedures/credential_set.h>
+#include <cardano/protocol_params/protocol_param_update.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Adds a protocol parameter change proposal to the transaction.
+ *
+ * This function creates a parameter change governance action from \p protocol_param_update,
+ * \p governance_action_id and \p policy_hash, wraps it in a proposal procedure funded with the
+ * governance action deposit from the state protocol parameters and adds it to the proposal
+ * procedures of the transaction body, creating the set when it is missing. It also adds an empty
+ * proposing redeemer for the proposal to the witness set so the constitution script can validate
+ * the proposal.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] protocol_param_update A pointer to the \ref cardano_protocol_param_update_t with the
+ *                                  parameter changes being proposed. This parameter must not be NULL.
+ * \param[in] governance_action_id A pointer to the \ref cardano_governance_action_id_t of the most
+ *                                 recently enacted action of this kind, or NULL when there is none.
+ * \param[in] policy_hash A pointer to the \ref cardano_blake2b_hash_t with the constitution script
+ *                        hash. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_parameter_change(
+  cardano_builder_state_t*         state,
+  cardano_reward_address_t*        reward_address,
+  cardano_anchor_t*                anchor,
+  cardano_protocol_param_update_t* protocol_param_update,
+  cardano_governance_action_id_t*  governance_action_id,
+  cardano_blake2b_hash_t*          policy_hash,
+  const char**                     error_message);
+
+/**
+ * \brief Adds a protocol parameter change proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor, governance action id and policy hash
+ * from their string representations and delegates to
+ * \ref cardano_builder_propose_parameter_change.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] gov_action_id A pointer to the bech32 string with the governance action id.
+ * \param[in] gov_action_id_size The size of the governance action id string in bytes.
+ * \param[in] policy_hash_hash_hex A pointer to the hex string with the constitution script hash.
+ * \param[in] policy_hash_hash_hex_size The size of the constitution script hash string in bytes.
+ * \param[in] protocol_param_update A pointer to the \ref cardano_protocol_param_update_t with the
+ *                                  parameter changes being proposed. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_parameter_change_ex(
+  cardano_builder_state_t*         state,
+  const char*                      reward_address,
+  size_t                           reward_address_size,
+  const char*                      metadata_url,
+  size_t                           metadata_url_size,
+  const char*                      metadata_hash_hex,
+  size_t                           metadata_hash_hex_size,
+  const char*                      gov_action_id,
+  size_t                           gov_action_id_size,
+  const char*                      policy_hash_hash_hex,
+  size_t                           policy_hash_hash_hex_size,
+  cardano_protocol_param_update_t* protocol_param_update,
+  const char**                     error_message);
+
+/**
+ * \brief Adds a hard fork initiation proposal to the transaction.
+ *
+ * This function creates a hard fork initiation governance action for \p version, wraps it in a
+ * proposal procedure funded with the governance action deposit from the state protocol parameters
+ * and adds it to the proposal procedures of the transaction body, creating the set when it is
+ * missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] version A pointer to the \ref cardano_protocol_version_t being proposed. This parameter
+ *                    must not be NULL.
+ * \param[in] governance_action_id A pointer to the \ref cardano_governance_action_id_t of the most
+ *                                 recently enacted action of this kind, or NULL when there is none.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_hardfork(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_protocol_version_t*     version,
+  cardano_governance_action_id_t* governance_action_id,
+  const char**                    error_message);
+
+/**
+ * \brief Adds a hard fork initiation proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor and governance action id from their
+ * string representations, builds the protocol version from its components and delegates to
+ * \ref cardano_builder_propose_hardfork.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] gov_action_id A pointer to the bech32 string with the governance action id.
+ * \param[in] gov_action_id_size The size of the governance action id string in bytes.
+ * \param[in] minor_protocol_version The minor component of the proposed protocol version.
+ * \param[in] major_protocol_version The major component of the proposed protocol version.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_hardfork_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   reward_address_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  const char*              gov_action_id,
+  size_t                   gov_action_id_size,
+  uint64_t                 minor_protocol_version,
+  uint64_t                 major_protocol_version,
+  const char**             error_message);
+
+/**
+ * \brief Adds a treasury withdrawals proposal to the transaction.
+ *
+ * This function creates a treasury withdrawals governance action from \p withdrawals and
+ * \p policy_hash, wraps it in a proposal procedure funded with the governance action deposit from
+ * the state protocol parameters and adds it to the proposal procedures of the transaction body,
+ * creating the set when it is missing. It also adds an empty proposing redeemer for the proposal
+ * to the witness set so the constitution script can validate the proposal.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] withdrawals A pointer to the \ref cardano_withdrawal_map_t with the reward addresses
+ *                        and amounts to withdraw from the treasury. This parameter must not be NULL.
+ * \param[in] policy_hash A pointer to the \ref cardano_blake2b_hash_t with the constitution script
+ *                        hash. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_treasury_withdrawals(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* reward_address,
+  cardano_anchor_t*         anchor,
+  cardano_withdrawal_map_t* withdrawals,
+  cardano_blake2b_hash_t*   policy_hash,
+  const char**              error_message);
+
+/**
+ * \brief Adds a treasury withdrawals proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor and policy hash from their string
+ * representations and delegates to \ref cardano_builder_propose_treasury_withdrawals.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] policy_hash_hash_hex A pointer to the hex string with the constitution script hash.
+ * \param[in] policy_hash_hash_hex_size The size of the constitution script hash string in bytes.
+ * \param[in] withdrawals A pointer to the \ref cardano_withdrawal_map_t with the reward addresses
+ *                        and amounts to withdraw from the treasury. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_treasury_withdrawals_ex(
+  cardano_builder_state_t*  state,
+  const char*               reward_address,
+  size_t                    reward_address_size,
+  const char*               metadata_url,
+  size_t                    metadata_url_size,
+  const char*               metadata_hash_hex,
+  size_t                    metadata_hash_hex_size,
+  const char*               policy_hash_hash_hex,
+  size_t                    policy_hash_hash_hex_size,
+  cardano_withdrawal_map_t* withdrawals,
+  const char**              error_message);
+
+/**
+ * \brief Adds a no confidence proposal to the transaction.
+ *
+ * This function creates a no confidence governance action, wraps it in a proposal procedure funded
+ * with the governance action deposit from the state protocol parameters and adds it to the proposal
+ * procedures of the transaction body, creating the set when it is missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] governance_action_id A pointer to the \ref cardano_governance_action_id_t of the most
+ *                                 recently enacted action of this kind, or NULL when there is none.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_no_confidence(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_governance_action_id_t* governance_action_id,
+  const char**                    error_message);
+
+/**
+ * \brief Adds a no confidence proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor and governance action id from their
+ * string representations and delegates to \ref cardano_builder_propose_no_confidence.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] gov_action_id A pointer to the bech32 string with the governance action id.
+ * \param[in] gov_action_id_size The size of the governance action id string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_no_confidence_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   reward_address_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  const char*              gov_action_id,
+  size_t                   gov_action_id_size,
+  const char**             error_message);
+
+/**
+ * \brief Adds an update committee proposal to the transaction.
+ *
+ * This function creates an update committee governance action from the members to remove, the
+ * members to add and the new quorum, wraps it in a proposal procedure funded with the governance
+ * action deposit from the state protocol parameters and adds it to the proposal procedures of the
+ * transaction body, creating the set when it is missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] governance_action_id A pointer to the \ref cardano_governance_action_id_t of the most
+ *                                 recently enacted action of this kind, or NULL when there is none.
+ * \param[in] members_to_be_removed A pointer to the \ref cardano_credential_set_t with the cold
+ *                                  credentials of the committee members to remove. This parameter
+ *                                  must not be NULL.
+ * \param[in] members_to_be_added A pointer to the \ref cardano_committee_members_map_t with the new
+ *                                committee members and their terms. This parameter must not be NULL.
+ * \param[in] new_quorum A pointer to the \ref cardano_unit_interval_t with the new committee quorum
+ *                       threshold. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_update_committee(
+  cardano_builder_state_t*         state,
+  cardano_reward_address_t*        reward_address,
+  cardano_anchor_t*                anchor,
+  cardano_governance_action_id_t*  governance_action_id,
+  cardano_credential_set_t*        members_to_be_removed,
+  cardano_committee_members_map_t* members_to_be_added,
+  cardano_unit_interval_t*         new_quorum,
+  const char**                     error_message);
+
+/**
+ * \brief Adds an update committee proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor and governance action id from their
+ * string representations, builds the quorum unit interval from a double and delegates to
+ * \ref cardano_builder_propose_update_committee.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] gov_action_id A pointer to the bech32 string with the governance action id.
+ * \param[in] gov_action_id_size The size of the governance action id string in bytes.
+ * \param[in] members_to_be_removed A pointer to the \ref cardano_credential_set_t with the cold
+ *                                  credentials of the committee members to remove. This parameter
+ *                                  must not be NULL.
+ * \param[in] members_to_be_added A pointer to the \ref cardano_committee_members_map_t with the new
+ *                                committee members and their terms. This parameter must not be NULL.
+ * \param[in] new_quorum The new committee quorum threshold as a value between 0 and 1.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_update_committee_ex(
+  cardano_builder_state_t*         state,
+  const char*                      reward_address,
+  size_t                           reward_address_size,
+  const char*                      metadata_url,
+  size_t                           metadata_url_size,
+  const char*                      metadata_hash_hex,
+  size_t                           metadata_hash_hex_size,
+  const char*                      gov_action_id,
+  size_t                           gov_action_id_size,
+  cardano_credential_set_t*        members_to_be_removed,
+  cardano_committee_members_map_t* members_to_be_added,
+  double                           new_quorum,
+  const char**                     error_message);
+
+/**
+ * \brief Adds a new constitution proposal to the transaction.
+ *
+ * This function creates a new constitution governance action from \p constitution, wraps it in a
+ * proposal procedure funded with the governance action deposit from the state protocol parameters
+ * and adds it to the proposal procedures of the transaction body, creating the set when it is
+ * missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[in] governance_action_id A pointer to the \ref cardano_governance_action_id_t of the most
+ *                                 recently enacted action of this kind, or NULL when there is none.
+ * \param[in] constitution A pointer to the \ref cardano_constitution_t being proposed. This
+ *                         parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_new_constitution(
+  cardano_builder_state_t*        state,
+  cardano_reward_address_t*       reward_address,
+  cardano_anchor_t*               anchor,
+  cardano_governance_action_id_t* governance_action_id,
+  cardano_constitution_t*         constitution,
+  const char**                    error_message);
+
+/**
+ * \brief Adds a new constitution proposal given its parts as strings.
+ *
+ * This function parses the reward address, metadata anchor and governance action id from their
+ * string representations and delegates to \ref cardano_builder_propose_new_constitution.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[in] gov_action_id A pointer to the bech32 string with the governance action id.
+ * \param[in] gov_action_id_size The size of the governance action id string in bytes.
+ * \param[in] constitution A pointer to the \ref cardano_constitution_t being proposed. This
+ *                         parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_new_constitution_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   reward_address_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  const char*              gov_action_id,
+  size_t                   gov_action_id_size,
+  cardano_constitution_t*  constitution,
+  const char**             error_message);
+
+/**
+ * \brief Adds an info proposal to the transaction.
+ *
+ * This function creates an info governance action, wraps it in a proposal procedure funded with
+ * the governance action deposit from the state protocol parameters and adds it to the proposal
+ * procedures of the transaction body, creating the set when it is missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the \ref cardano_reward_address_t that receives the deposit
+ *                           refund. This parameter must not be NULL.
+ * \param[in] anchor A pointer to the \ref cardano_anchor_t with the proposal metadata. This
+ *                   parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_info(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* reward_address,
+  cardano_anchor_t*         anchor,
+  const char**              error_message);
+
+/**
+ * \brief Adds an info proposal given its parts as strings.
+ *
+ * This function parses the reward address and metadata anchor from their string representations
+ * and delegates to \ref cardano_builder_propose_info.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] reward_address_size The size of the reward address string in bytes.
+ * \param[in] metadata_url A pointer to the string with the metadata URL of the anchor.
+ * \param[in] metadata_url_size The size of the metadata URL string in bytes.
+ * \param[in] metadata_hash_hex A pointer to the hex string with the metadata hash of the anchor.
+ * \param[in] metadata_hash_hex_size The size of the metadata hash string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the proposal was added, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_propose_info_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   reward_address_size,
+  const char*              metadata_url,
+  size_t                   metadata_url_size,
+  const char*              metadata_hash_hex,
+  size_t                   metadata_hash_hex_size,
+  const char**             error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_PROPOSALS_H

--- a/lib/src/transaction_builder/internals/builder_redeemers.c
+++ b/lib/src/transaction_builder/internals/builder_redeemers.c
@@ -1,0 +1,232 @@
+/**
+ * \file builder_redeemers.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_redeemers.h"
+
+#include <cardano/common/ex_units.h>
+#include <cardano/plutus_data/constr_plutus_data.h>
+#include <cardano/plutus_data/plutus_list.h>
+#include <cardano/witness_set/redeemer_list.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_add_redeemer(
+  cardano_witness_set_t*       witness_set,
+  cardano_blake2b_hash_t*      hash,
+  cardano_plutus_data_t*       data,
+  const cardano_redeemer_tag_t tag,
+  cardano_builder_state_t*     state,
+  const char**                 error_message)
+{
+  cardano_error_t          result    = CARDANO_SUCCESS;
+  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witness_set);
+
+  if (redeemers == NULL)
+  {
+    result = cardano_redeemer_list_new(&redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_witness_set_set_redeemers(witness_set, redeemers);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      cardano_redeemer_list_unref(&redeemers);
+      return result;
+    }
+  }
+
+  cardano_redeemer_list_unref(&redeemers);
+
+  if (data != NULL)
+  {
+    cardano_redeemer_t* rdmer = NULL;
+
+    cardano_ex_units_t* ex_units = NULL;
+    result                       = cardano_ex_units_new(0, 0, &ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_redeemer_new(tag, 0, data, ex_units, &rdmer);
+    cardano_ex_units_unref(&ex_units);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    bool duplicate = false;
+
+    switch (tag)
+    {
+      case CARDANO_REDEEMER_TAG_MINT:
+      {
+        result = cardano_blake2b_hash_to_redeemer_map_insert(state->mints_to_redeemer_map, hash, rdmer);
+
+        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+        {
+          *error_message = "Failed to insert plutus data to redeemer map.";
+
+          cardano_redeemer_unref(&rdmer);
+
+          return result;
+        }
+
+        if (result == CARDANO_ERROR_DUPLICATED_KEY)
+        {
+          duplicate = true;
+          result    = CARDANO_SUCCESS;
+        }
+
+        break;
+      }
+      case CARDANO_REDEEMER_TAG_REWARD:
+      {
+        result = cardano_blake2b_hash_to_redeemer_map_insert(state->withdrawals_to_redeemer_map, hash, rdmer);
+
+        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+        {
+          *error_message = "Failed to insert plutus data to redeemer map.";
+
+          cardano_redeemer_unref(&rdmer);
+
+          return result;
+        }
+
+        if (result == CARDANO_ERROR_DUPLICATED_KEY)
+        {
+          duplicate = true;
+          result    = CARDANO_SUCCESS;
+        }
+
+        break;
+      }
+      case CARDANO_REDEEMER_TAG_VOTING:
+      {
+        result = cardano_blake2b_hash_to_redeemer_map_insert(state->votes_to_redeemer_map, hash, rdmer);
+
+        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+        {
+          *error_message = "Failed to insert plutus data to redeemer map.";
+
+          cardano_redeemer_unref(&rdmer);
+
+          return result;
+        }
+
+        if (result == CARDANO_ERROR_DUPLICATED_KEY)
+        {
+          duplicate = true;
+          result    = CARDANO_SUCCESS;
+        }
+
+        break;
+      }
+      case CARDANO_REDEEMER_TAG_CERTIFYING:
+      case CARDANO_REDEEMER_TAG_PROPOSING:
+      case CARDANO_REDEEMER_TAG_SPEND:
+      case CARDANO_REDEEMER_TAG_GUARDING:
+      default:
+      {
+        *error_message = "Invalid redeemer tag.";
+        cardano_redeemer_unref(&rdmer);
+
+        return CARDANO_ERROR_ILLEGAL_STATE;
+      }
+    }
+
+    if (!duplicate)
+    {
+      result = cardano_redeemer_list_add(redeemers, rdmer);
+    }
+
+    cardano_redeemer_unref(&rdmer);
+  }
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_create_placeholder_plutus_data(cardano_plutus_data_t** data)
+{
+  cardano_plutus_list_t* fields = NULL;
+
+  cardano_error_t result = cardano_plutus_list_new(&fields);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_constr_plutus_data_t* constr = NULL;
+
+  result = cardano_constr_plutus_data_new(0U, fields, &constr);
+
+  cardano_plutus_list_unref(&fields);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_plutus_data_new_constr(constr, data);
+
+  cardano_constr_plutus_data_unref(&constr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_register_deferred_from_map(
+  cardano_builder_state_t*                state,
+  cardano_blake2b_hash_to_redeemer_map_t* map,
+  cardano_blake2b_hash_t*                 hash,
+  cardano_deferred_redeemer_fn_t          callback,
+  void*                                   user_context,
+  const char**                            error_message)
+{
+  cardano_redeemer_t* redeemer = NULL;
+
+  cardano_error_t result = cardano_blake2b_hash_to_redeemer_map_get(map, hash, &redeemer);
+
+  if (result == CARDANO_SUCCESS)
+  {
+    result = cardano_deferred_redeemer_list_add(state->deferred_redeemers, redeemer, callback, user_context);
+  }
+
+  cardano_redeemer_unref(&redeemer);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to register the deferred redeemer.";
+  }
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_redeemers.h
+++ b/lib/src/transaction_builder/internals/builder_redeemers.h
@@ -1,0 +1,129 @@
+/**
+ * \file builder_redeemers.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_REDEEMERS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_REDEEMERS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+#include <cardano/witness_set/redeemer.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "blake2b_hash_to_redeemer_map.h"
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Adds a redeemer for the given tag to a witness set and records it in the matching redeemer map.
+ *
+ * This function ensures the witness set has a redeemer list, creating and attaching an empty one when it
+ * is missing. When \p data is not NULL it creates a redeemer with the given tag, a zero index and zero
+ * execution units, inserts it keyed by \p hash into the state redeemer map that matches the tag (mint,
+ * reward or vote) and appends it to the witness set redeemer list unless the key was already present in
+ * the map.
+ *
+ * \param[in,out] witness_set A pointer to the \ref cardano_witness_set_t that receives the redeemer. This
+ *                            parameter must not be NULL.
+ * \param[in] hash A pointer to the \ref cardano_blake2b_hash_t used as the key in the redeemer map. This
+ *                 parameter must not be NULL.
+ * \param[in] data A pointer to the \ref cardano_plutus_data_t with the redeemer payload, or NULL to only
+ *                 ensure the witness set redeemer list exists.
+ * \param[in] tag The \ref cardano_redeemer_tag_t identifying the redeemer purpose. Only the mint, reward
+ *                and vote tags are accepted.
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t holding the redeemer maps. This
+ *                      parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the redeemer was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_redeemer(
+  cardano_witness_set_t*   witness_set,
+  cardano_blake2b_hash_t*  hash,
+  cardano_plutus_data_t*   data,
+  cardano_redeemer_tag_t   tag,
+  cardano_builder_state_t* state,
+  const char**             error_message);
+
+/**
+ * \brief Creates the placeholder payload used by deferred redeemers until they are resolved.
+ *
+ * The placeholder is an empty constructor (constr 0 []), so the transaction can be sized and
+ * hashed before the first balancing iteration replaces it with the real payload.
+ *
+ * \param[out] data A pointer to a pointer to a \ref cardano_plutus_data_t. On success it points to the
+ *                  newly created placeholder and the caller must release it with
+ *                  \ref cardano_plutus_data_unref. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS on success, or an appropriate error code.
+ */
+cardano_error_t
+cardano_builder_create_placeholder_plutus_data(cardano_plutus_data_t** data);
+
+/**
+ * \brief Registers a deferred callback for the redeemer stored under the given hash in one of
+ * the builder state redeemer maps.
+ *
+ * This function looks up the redeemer keyed by \p hash in \p map and, when found, adds it to the
+ * state deferred redeemer list together with the callback and its context so the payload can be
+ * resolved during balancing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t holding the deferred redeemer
+ *                      list. This parameter must not be NULL.
+ * \param[in] map A pointer to the \ref cardano_blake2b_hash_to_redeemer_map_t holding the redeemer
+ *                (mint, withdrawal or vote map). This parameter must not be NULL.
+ * \param[in] hash A pointer to the \ref cardano_blake2b_hash_t key of the redeemer in the map. This
+ *                 parameter must not be NULL.
+ * \param[in] callback The deferred redeemer callback invoked during balancing.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the deferred redeemer was registered, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_register_deferred_from_map(
+  cardano_builder_state_t*                state,
+  cardano_blake2b_hash_to_redeemer_map_t* map,
+  cardano_blake2b_hash_t*                 hash,
+  cardano_deferred_redeemer_fn_t          callback,
+  void*                                   user_context,
+  const char**                            error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_REDEEMERS_H

--- a/lib/src/transaction_builder/internals/builder_state.c
+++ b/lib/src/transaction_builder/internals/builder_state.c
@@ -1,0 +1,270 @@
+/**
+ * \file builder_state.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_state.h"
+
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/transaction_body/transaction_input_set.h>
+#include <cardano/transaction_body/transaction_output_list.h>
+#include <cardano/transaction_builder/coin_selection/random_improve_coin_selector.h>
+#include <cardano/transaction_builder/evaluation/native_tx_evaluator.h>
+#include <cardano/witness_set/witness_set.h>
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Creates and initializes a new, empty transaction.
+ *
+ * This function allocates and initializes a new instance of a \ref cardano_transaction_t object.
+ *
+ * \return A pointer to the newly created \ref cardano_transaction_t object if successful. Returns
+ * \c NULL if memory allocation fails.
+ */
+static cardano_transaction_t*
+transaction_new(void)
+{
+  cardano_transaction_body_t*        body        = NULL;
+  cardano_transaction_input_set_t*   inputs      = NULL;
+  cardano_transaction_output_list_t* outputs     = NULL;
+  cardano_witness_set_t*             witnesses   = NULL;
+  cardano_transaction_t*             transaction = NULL;
+
+  cardano_error_t result = cardano_transaction_input_set_new(&inputs);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return NULL;
+  }
+
+  result = cardano_transaction_output_list_new(&outputs);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_transaction_input_set_unref(&inputs);
+    return NULL;
+  }
+
+  result = cardano_transaction_body_new(inputs, outputs, 0U, NULL, &body);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_transaction_input_set_unref(&inputs);
+    cardano_transaction_output_list_unref(&outputs);
+    return NULL;
+  }
+
+  result = cardano_witness_set_new(&witnesses);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_transaction_input_set_unref(&inputs);
+    cardano_transaction_output_list_unref(&outputs);
+    cardano_transaction_body_unref(&body);
+    return NULL;
+  }
+
+  result = cardano_transaction_new(body, witnesses, NULL, &transaction);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_transaction_input_set_unref(&inputs);
+    cardano_transaction_output_list_unref(&outputs);
+    cardano_transaction_body_unref(&body);
+    cardano_witness_set_unref(&witnesses);
+
+    return NULL;
+  }
+
+  cardano_transaction_input_set_unref(&inputs);
+  cardano_transaction_output_list_unref(&outputs);
+  cardano_transaction_body_unref(&body);
+  cardano_witness_set_unref(&witnesses);
+
+  return transaction;
+}
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_state_init(
+  cardano_builder_state_t*       state,
+  cardano_protocol_parameters_t* params,
+  const cardano_slot_config_t*   slot_config)
+{
+  if ((state == NULL) || (params == NULL) || (slot_config == NULL))
+  {
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  state->transaction                 = NULL;
+  state->params                      = NULL;
+  state->slot_config                 = *slot_config;
+  state->coin_selector               = NULL;
+  state->tx_evaluator                = NULL;
+  state->change_address              = NULL;
+  state->collateral_address          = NULL;
+  state->available_utxos             = NULL;
+  state->collateral_utxos            = NULL;
+  state->pre_selected_inputs         = NULL;
+  state->reference_inputs            = NULL;
+  state->input_to_redeemer_map       = NULL;
+  state->withdrawals_to_redeemer_map = NULL;
+  state->mints_to_redeemer_map       = NULL;
+  state->votes_to_redeemer_map       = NULL;
+  state->deferred_redeemers          = NULL;
+  state->tx_evaluator                = NULL;
+
+  cardano_protocol_parameters_ref(params);
+  state->params = params;
+
+  cardano_error_t result = cardano_random_improve_coin_selector_new(&state->coin_selector);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  state->transaction = transaction_new();
+
+  if (state->transaction == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  state->change_address             = NULL;
+  state->collateral_address         = NULL;
+  state->available_utxos            = NULL;
+  state->collateral_utxos           = NULL;
+  state->pre_selected_inputs        = NULL;
+  state->reference_inputs           = NULL;
+  state->has_plutus_v1              = false;
+  state->has_plutus_v2              = false;
+  state->has_plutus_v3              = false;
+  state->additional_signature_count = 0U;
+
+  result = cardano_utxo_list_new(&state->pre_selected_inputs);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_utxo_list_new(&state->reference_inputs);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_input_to_redeemer_map_new(&state->input_to_redeemer_map);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_blake2b_hash_to_redeemer_map_new(&state->withdrawals_to_redeemer_map);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_blake2b_hash_to_redeemer_map_new(&state->mints_to_redeemer_map);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_blake2b_hash_to_redeemer_map_new(&state->votes_to_redeemer_map);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  result = cardano_deferred_redeemer_list_new(&state->deferred_redeemers);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_costmdls_t*         cost_models    = cardano_protocol_parameters_get_cost_models(state->params);
+  cardano_protocol_version_t* version        = cardano_protocol_parameters_get_protocol_version(state->params);
+  const uint64_t              protocol_major = cardano_protocol_version_get_major(version);
+
+  result = cardano_tx_evaluator_new_native(&state->slot_config, cost_models, protocol_major, &state->tx_evaluator);
+
+  cardano_costmdls_unref(&cost_models);
+  cardano_protocol_version_unref(&version);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+void
+cardano_builder_state_release(cardano_builder_state_t* state)
+{
+  if (state == NULL)
+  {
+    return;
+  }
+
+  cardano_transaction_unref(&state->transaction);
+  cardano_protocol_parameters_unref(&state->params);
+  cardano_coin_selector_unref(&state->coin_selector);
+  cardano_tx_evaluator_unref(&state->tx_evaluator);
+  cardano_address_unref(&state->change_address);
+  cardano_address_unref(&state->collateral_address);
+  cardano_utxo_list_unref(&state->available_utxos);
+  cardano_utxo_list_unref(&state->collateral_utxos);
+  cardano_utxo_list_unref(&state->pre_selected_inputs);
+  cardano_utxo_list_unref(&state->reference_inputs);
+  cardano_input_to_redeemer_map_unref(&state->input_to_redeemer_map);
+  cardano_blake2b_hash_to_redeemer_map_unref(&state->withdrawals_to_redeemer_map);
+  cardano_blake2b_hash_to_redeemer_map_unref(&state->mints_to_redeemer_map);
+  cardano_blake2b_hash_to_redeemer_map_unref(&state->votes_to_redeemer_map);
+  cardano_deferred_redeemer_list_unref(&state->deferred_redeemers);
+
+  state->transaction                 = NULL;
+  state->params                      = NULL;
+  state->coin_selector               = NULL;
+  state->tx_evaluator                = NULL;
+  state->change_address              = NULL;
+  state->collateral_address          = NULL;
+  state->available_utxos             = NULL;
+  state->collateral_utxos            = NULL;
+  state->pre_selected_inputs         = NULL;
+  state->reference_inputs            = NULL;
+  state->input_to_redeemer_map       = NULL;
+  state->withdrawals_to_redeemer_map = NULL;
+  state->mints_to_redeemer_map       = NULL;
+  state->votes_to_redeemer_map       = NULL;
+  state->deferred_redeemers          = NULL;
+}

--- a/lib/src/transaction_builder/internals/builder_state.h
+++ b/lib/src/transaction_builder/internals/builder_state.h
@@ -1,0 +1,162 @@
+/**
+ * \file builder_state.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_STATE_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_STATE_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/address.h>
+#include <cardano/common/utxo_list.h>
+#include <cardano/error.h>
+#include <cardano/protocol_params/protocol_parameters.h>
+#include <cardano/slot_config.h>
+#include <cardano/transaction/transaction.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+#include <cardano/transaction_builder/balancing/input_to_redeemer_map.h>
+#include <cardano/transaction_builder/coin_selection/coin_selector.h>
+#include <cardano/transaction_builder/evaluation/tx_evaluator.h>
+#include <cardano/typedefs.h>
+
+#include "blake2b_hash_to_redeemer_map.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Holds everything a transaction builder tracks while assembling a transaction.
+ *
+ * The `cardano_builder_state_t` structure carries the transaction under construction together
+ * with the protocol parameters, selection strategies, addresses, UTXO lists, script language
+ * flags and redeemer bookkeeping that the builder consults when balancing and finalizing the
+ * transaction.
+ */
+typedef struct cardano_builder_state_t
+{
+    /** \brief The transaction being incrementally assembled by the builder. */
+    cardano_transaction_t* transaction;
+
+    /** \brief The protocol parameters used for fee, deposit and size computations. */
+    cardano_protocol_parameters_t* params;
+
+    /** \brief The slot timing configuration used to convert between Unix time and slots. */
+    cardano_slot_config_t slot_config;
+
+    /** \brief The coin selection strategy used to pick inputs during balancing. */
+    cardano_coin_selector_t* coin_selector;
+
+    /** \brief The evaluator used to compute execution units for Plutus scripts. */
+    cardano_tx_evaluator_t* tx_evaluator;
+
+    /** \brief The address that receives any change produced while balancing. */
+    cardano_address_t* change_address;
+
+    /** \brief The address that receives any collateral change output. */
+    cardano_address_t* collateral_address;
+
+    /** \brief The UTXO set available to the coin selector for input selection. */
+    cardano_utxo_list_t* available_utxos;
+
+    /** \brief The UTXO set available for collateral selection. */
+    cardano_utxo_list_t* collateral_utxos;
+
+    /** \brief The inputs explicitly added by the caller that must be spent by the transaction. */
+    cardano_utxo_list_t* pre_selected_inputs;
+
+    /** \brief The reference inputs added to the transaction. */
+    cardano_utxo_list_t* reference_inputs;
+
+    /** \brief Whether the transaction uses at least one Plutus V1 script. */
+    bool has_plutus_v1;
+
+    /** \brief Whether the transaction uses at least one Plutus V2 script. */
+    bool has_plutus_v2;
+
+    /** \brief Whether the transaction uses at least one Plutus V3 script. */
+    bool has_plutus_v3;
+
+    /** \brief The number of additional signatures accounted for when computing fees. */
+    size_t additional_signature_count;
+
+    /** \brief Maps transaction inputs to their spend redeemers. */
+    cardano_input_to_redeemer_map_t* input_to_redeemer_map;
+
+    /** \brief Maps reward credential hashes to their withdrawal redeemers. */
+    cardano_blake2b_hash_to_redeemer_map_t* withdrawals_to_redeemer_map;
+
+    /** \brief Maps minting policy hashes to their mint redeemers. */
+    cardano_blake2b_hash_to_redeemer_map_t* mints_to_redeemer_map;
+
+    /** \brief Maps voter credential hashes to their voting redeemers. */
+    cardano_blake2b_hash_to_redeemer_map_t* votes_to_redeemer_map;
+
+    /** \brief The redeemers whose indices are resolved when the transaction is balanced. */
+    cardano_deferred_redeemer_list_t* deferred_redeemers;
+} cardano_builder_state_t;
+
+/**
+ * \brief Initializes a builder state with its default contents.
+ *
+ * This function initializes every field of the given state, takes a reference on the provided
+ * protocol parameters, copies the slot configuration and creates the objects the builder starts
+ * from: a random improve coin selector, an empty transaction, the pre selected and reference
+ * input lists, the redeemer maps, the deferred redeemer list and a native transaction evaluator
+ * configured from the protocol parameters cost models and protocol version.
+ *
+ * \param[out] state A pointer to the \ref cardano_builder_state_t to initialize. This parameter
+ *                   must not be NULL.
+ * \param[in] params A pointer to the \ref cardano_protocol_parameters_t used by the builder. The
+ *                   state holds a reference to this object until it is released. This parameter
+ *                   must not be NULL.
+ * \param[in] slot_config A pointer to the \ref cardano_slot_config_t copied into the state. This
+ *                        parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the state was fully initialized, or an appropriate error code
+ *         indicating the failure reason. On failure the state may be partially initialized and
+ *         the caller must release it with \ref cardano_builder_state_release.
+ */
+cardano_error_t
+cardano_builder_state_init(
+  cardano_builder_state_t*       state,
+  cardano_protocol_parameters_t* params,
+  const cardano_slot_config_t*   slot_config);
+
+/**
+ * \brief Releases every object held by a builder state.
+ *
+ * This function releases the references the state holds on the transaction, protocol parameters,
+ * coin selector, transaction evaluator, addresses, UTXO lists, redeemer maps and deferred
+ * redeemer list, setting each pointer field to NULL. It does not free the state itself. Calling
+ * it on an already released state or with NULL has no effect.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t to release.
+ */
+void
+cardano_builder_state_release(cardano_builder_state_t* state);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_STATE_H

--- a/lib/src/transaction_builder/internals/builder_votes.c
+++ b/lib/src/transaction_builder/internals/builder_votes.c
@@ -1,0 +1,280 @@
+/**
+ * \file builder_votes.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_votes.h"
+
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/voting_procedures/voting_procedures.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "../../allocators.h"
+#include "../../string_safe.h"
+#include "builder_redeemers.h"
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Computes a deterministic, sortable hash ID for a voter.
+ *
+ * This function creates an identifier by concatenating the voter's type and credential hash.
+ *
+ * This ID can be used to establish a canonical sorting order for a voter's redeemer.
+ *
+ * \param[in] voter A pointer to the `cardano_voter_t` object.
+ * \param[out] id On success, this will be populated with a pointer to a newly allocated
+ * `cardano_blake2b_hash_t` object representing the unique ID.
+ *
+ * \return `CARDANO_SUCCESS` if the ID was computed successfully. Returns an appropriate
+ * error code on failure.
+ *
+ * \note The caller is responsible for managing the lifecycle of the returned `id` object
+ * and must release it by calling `cardano_blake2b_hash_unref`.
+ */
+static cardano_error_t
+compute_voting_procedures_sortable_id(cardano_voter_t* voter, cardano_blake2b_hash_t** id)
+{
+  if ((id == NULL) || (voter == NULL))
+  {
+    return CARDANO_ERROR_INVALID_ARGUMENT;
+  }
+
+  cardano_error_t result = CARDANO_SUCCESS;
+
+  cardano_credential_t*   credential = cardano_voter_get_credential(voter);
+  cardano_blake2b_hash_t* hash       = cardano_credential_get_hash(credential);
+
+  const byte_t* hash_bytes = cardano_blake2b_hash_get_data(hash);
+  size_t        hash_size  = cardano_blake2b_hash_get_bytes_size(hash);
+
+  cardano_voter_type_t voter_type;
+  result = cardano_voter_get_type(voter, &voter_type);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    cardano_blake2b_hash_unref(&hash);
+    cardano_credential_unref(&credential);
+    return result;
+  }
+
+  const size_t total_size = sizeof(voter_type) + hash_size;
+  byte_t*      id_bytes   = (byte_t*)_cardano_malloc(total_size);
+
+  if (id_bytes == NULL)
+  {
+    cardano_blake2b_hash_unref(&hash);
+    cardano_credential_unref(&credential);
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  size_t cursor = 0;
+
+  cardano_safe_memcpy(&id_bytes[cursor], total_size, &voter_type, sizeof(voter_type));
+  cursor += sizeof(voter_type);
+
+  cardano_safe_memcpy(&id_bytes[cursor], total_size - cursor, hash_bytes, hash_size);
+
+  cardano_blake2b_hash_unref(&hash);
+  cardano_credential_unref(&credential);
+
+  cardano_blake2b_hash_t* id_hash = NULL;
+  result                          = cardano_blake2b_hash_from_bytes(id_bytes, total_size, &id_hash);
+
+  _cardano_free(id_bytes);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  *id = id_hash;
+
+  return CARDANO_SUCCESS;
+}
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_vote(
+  cardano_builder_state_t*        state,
+  cardano_voter_t*                voter,
+  cardano_governance_action_id_t* action_id,
+  cardano_voting_procedure_t*     vote,
+  cardano_plutus_data_t*          redeemer,
+  const char**                    error_message)
+{
+  if (voter == NULL)
+  {
+    *error_message = "Voter is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (action_id == NULL)
+  {
+    *error_message = "Action ID is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (vote == NULL)
+  {
+    *error_message = "Vote is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_voting_procedures_t* votes = cardano_transaction_body_get_voting_procedures(body);
+
+  if (votes == NULL)
+  {
+    cardano_error_t result = cardano_voting_procedures_new(&votes);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create voting procedures.";
+
+      return result;
+    }
+
+    result = cardano_transaction_body_set_voting_procedures(body, votes);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set voting procedures.";
+      cardano_voting_procedures_unref(&votes);
+
+      return result;
+    }
+  }
+
+  cardano_voting_procedures_unref(&votes);
+
+  cardano_error_t result = cardano_voting_procedures_insert(votes, voter, action_id, vote);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to insert vote.";
+
+    return result;
+  }
+
+  cardano_blake2b_hash_t* id_hash = NULL;
+  result                          = compute_voting_procedures_sortable_id(voter, &id_hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create voting procedure ID hash.";
+
+    return result;
+  }
+
+  if (redeemer != NULL)
+  {
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+    cardano_witness_set_unref(&witnesses);
+
+    result = cardano_builder_add_redeemer(witnesses, id_hash, redeemer, CARDANO_REDEEMER_TAG_VOTING, state, error_message);
+    cardano_blake2b_hash_unref(&id_hash);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add redeemer.";
+
+      return result;
+    }
+  }
+  else
+  {
+    result = cardano_blake2b_hash_to_redeemer_map_insert(state->votes_to_redeemer_map, id_hash, NULL);
+
+    if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+    {
+      cardano_blake2b_hash_unref(&id_hash);
+      *error_message = "Failed to add vote redeemer placeholder.";
+
+      return result;
+    }
+
+    cardano_blake2b_hash_unref(&id_hash);
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_vote_with_deferred_redeemer(
+  cardano_builder_state_t*        state,
+  cardano_voter_t*                voter,
+  cardano_governance_action_id_t* action_id,
+  cardano_voting_procedure_t*     vote,
+  cardano_deferred_redeemer_fn_t  callback,
+  void*                           user_context,
+  const char**                    error_message)
+{
+  if ((voter == NULL) || (action_id == NULL) || (vote == NULL) || (callback == NULL))
+  {
+    *error_message = "Voter, action id, vote and callback are required";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_plutus_data_t* placeholder = NULL;
+
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create the placeholder redeemer.";
+
+    return result;
+  }
+
+  result = cardano_builder_vote(state, voter, action_id, vote, placeholder, error_message);
+
+  cardano_plutus_data_unref(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_blake2b_hash_t* hash = NULL;
+
+  result = compute_voting_procedures_sortable_id(voter, &hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to compute the vote sortable id.";
+
+    return result;
+  }
+
+  result = cardano_builder_register_deferred_from_map(state, state->votes_to_redeemer_map, hash, callback, user_context, error_message);
+
+  cardano_blake2b_hash_unref(&hash);
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_votes.h
+++ b/lib/src/transaction_builder/internals/builder_votes.h
@@ -1,0 +1,116 @@
+/**
+ * \file builder_votes.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_VOTES_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_VOTES_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/common/governance_action_id.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+#include <cardano/voting_procedures/voter.h>
+#include <cardano/voting_procedures/voting_procedure.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Records a vote for a governance action in the transaction.
+ *
+ * This function inserts the voting procedure for \p voter and \p action_id into the voting
+ * procedures of the transaction body, creating the collection when it is missing. When
+ * \p redeemer is not NULL it is attached as a voting redeemer keyed by the sortable id of the
+ * voter in the state vote redeemer map. When \p redeemer is NULL the sortable id is still
+ * recorded in the map with a NULL redeemer so redeemer indices can be computed.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] voter A pointer to the \ref cardano_voter_t casting the vote. This parameter must not
+ *                  be NULL.
+ * \param[in] action_id A pointer to the \ref cardano_governance_action_id_t of the governance action
+ *                      being voted on. This parameter must not be NULL.
+ * \param[in] vote A pointer to the \ref cardano_voting_procedure_t with the vote to record. This
+ *                 parameter must not be NULL.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as voting redeemer payload,
+ *                     or NULL when the voter does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the vote was recorded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_builder_vote(
+  cardano_builder_state_t*        state,
+  cardano_voter_t*                voter,
+  cardano_governance_action_id_t* action_id,
+  cardano_voting_procedure_t*     vote,
+  cardano_plutus_data_t*          redeemer,
+  const char**                    error_message);
+
+/**
+ * \brief Records a vote whose redeemer payload is resolved during balancing.
+ *
+ * This function records the vote with an empty placeholder redeemer and registers the callback in
+ * the state deferred redeemer list keyed by the sortable id of the voter. The callback is invoked
+ * while the transaction is balanced to produce the final redeemer payload.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] voter A pointer to the \ref cardano_voter_t casting the vote. This parameter must not
+ *                  be NULL.
+ * \param[in] action_id A pointer to the \ref cardano_governance_action_id_t of the governance action
+ *                      being voted on. This parameter must not be NULL.
+ * \param[in] vote A pointer to the \ref cardano_voting_procedure_t with the vote to record. This
+ *                 parameter must not be NULL.
+ * \param[in] callback The deferred redeemer callback invoked during balancing. This parameter must
+ *                     not be NULL.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the vote and callback were registered, or an appropriate error
+ *         code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_vote_with_deferred_redeemer(
+  cardano_builder_state_t*        state,
+  cardano_voter_t*                voter,
+  cardano_governance_action_id_t* action_id,
+  cardano_voting_procedure_t*     vote,
+  cardano_deferred_redeemer_fn_t  callback,
+  void*                           user_context,
+  const char**                    error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_VOTES_H

--- a/lib/src/transaction_builder/internals/builder_withdrawals.c
+++ b/lib/src/transaction_builder/internals/builder_withdrawals.c
@@ -1,0 +1,308 @@
+/**
+ * \file builder_withdrawals.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_withdrawals.h"
+
+#include <cardano/common/withdrawal_map.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/witness_set/witness_set.h>
+
+#include "../../allocators.h"
+#include "../../string_safe.h"
+#include "builder_redeemers.h"
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * \brief Computes a deterministic, sortable hash ID for a credential.
+ *
+ * This function creates a unique identifier by concatenating the credential's type
+ * and its raw hash bytes.
+ *
+ * \param[in] credential A pointer to the `cardano_credential_t` object.
+ * \param[out] id On success, this will be populated with a pointer to a newly allocated
+ * `cardano_blake2b_hash_t` object representing the unique ID.
+ *
+ * \return `CARDANO_SUCCESS` if the ID was computed successfully, or an appropriate
+ * error code on failure.
+ *
+ * \note The caller is responsible for managing the lifecycle of the returned `id` object
+ * and must release it by calling `cardano_blake2b_hash_unref`.
+ */
+static cardano_error_t
+compute_credential_sortable_id(cardano_credential_t* credential, cardano_blake2b_hash_t** id)
+{
+  if ((credential == NULL) || (id == NULL))
+  {
+    return CARDANO_ERROR_INVALID_ARGUMENT;
+  }
+
+  cardano_credential_type_t type;
+  cardano_error_t           result = cardano_credential_get_type(credential, &type);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_blake2b_hash_t* hash       = cardano_credential_get_hash(credential);
+  const byte_t*           hash_bytes = cardano_blake2b_hash_get_data(hash);
+  size_t                  hash_size  = cardano_blake2b_hash_get_bytes_size(hash);
+
+  const size_t total_size = sizeof(type) + hash_size;
+  byte_t*      id_bytes   = (byte_t*)_cardano_malloc(total_size);
+
+  if (id_bytes == NULL)
+  {
+    cardano_blake2b_hash_unref(&hash);
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  size_t cursor = 0;
+
+  cardano_safe_memcpy(&id_bytes[cursor], total_size, &type, sizeof(type));
+  cursor += sizeof(type);
+
+  cardano_safe_memcpy(&id_bytes[cursor], total_size - cursor, hash_bytes, hash_size);
+
+  cardano_blake2b_hash_unref(&hash);
+
+  result = cardano_blake2b_hash_from_bytes(id_bytes, total_size, id);
+
+  _cardano_free(id_bytes);
+
+  return result;
+}
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_withdraw_rewards(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  const int64_t             amount,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message)
+{
+  if (address == NULL)
+  {
+    *error_message = "Reward address is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  if (amount < 0)
+  {
+    *error_message = "Amount must be greater than zero.";
+
+    return CARDANO_ERROR_INVALID_ARGUMENT;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_withdrawal_map_t* withdrawals = cardano_transaction_body_get_withdrawals(body);
+
+  if (withdrawals == NULL)
+  {
+    cardano_error_t result = cardano_withdrawal_map_new(&withdrawals);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create withdrawal map.";
+
+      return result;
+    }
+
+    result = cardano_transaction_body_set_withdrawals(body, withdrawals);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set withdrawal map.";
+      cardano_withdrawal_map_unref(&withdrawals);
+
+      return result;
+    }
+  }
+
+  cardano_withdrawal_map_unref(&withdrawals);
+
+  cardano_error_t result = cardano_withdrawal_map_insert(withdrawals, address, amount);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to insert withdrawal.";
+
+    return result;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  cardano_blake2b_hash_t* hash = NULL;
+
+  result = compute_credential_sortable_id(credential, &hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to compute credential sortable ID.";
+
+    return result;
+  }
+
+  if (redeemer != NULL)
+  {
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state->transaction);
+    cardano_witness_set_unref(&witnesses);
+
+    result = cardano_builder_add_redeemer(witnesses, hash, redeemer, CARDANO_REDEEMER_TAG_REWARD, state, error_message);
+
+    cardano_blake2b_hash_unref(&hash);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to add redeemer.";
+
+      return result;
+    }
+  }
+  else
+  {
+    cardano_credential_type_t cred_type = CARDANO_CREDENTIAL_TYPE_KEY_HASH;
+    result                              = cardano_credential_get_type(credential, &cred_type);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      cardano_blake2b_hash_unref(&hash);
+      *error_message = "Failed to add withdrawal.";
+
+      return result;
+    }
+
+    if (cred_type != CARDANO_CREDENTIAL_TYPE_KEY_HASH)
+    {
+      result = cardano_blake2b_hash_to_redeemer_map_insert(state->withdrawals_to_redeemer_map, hash, NULL);
+
+      if (result != CARDANO_SUCCESS)
+      {
+        cardano_blake2b_hash_unref(&hash);
+        *error_message = "Failed to add withdrawal.";
+
+        return result;
+      }
+    }
+
+    cardano_blake2b_hash_unref(&hash);
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_withdraw_rewards_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  const int64_t            amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message)
+{
+  if ((reward_address == NULL) || (address_size == 0U))
+  {
+    *error_message = "Reward address is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_reward_address_t* addr   = NULL;
+  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse reward address.";
+
+    return result;
+  }
+
+  result = cardano_builder_withdraw_rewards(state, addr, amount, redeemer, error_message);
+  cardano_reward_address_unref(&addr);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_withdraw_rewards_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_reward_address_t*      address,
+  const int64_t                  amount,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message)
+{
+  if ((address == NULL) || (callback == NULL))
+  {
+    *error_message = "Reward address and callback are required";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_plutus_data_t* placeholder = NULL;
+
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create the placeholder redeemer.";
+
+    return result;
+  }
+
+  result = cardano_builder_withdraw_rewards(state, address, amount, placeholder, error_message);
+
+  cardano_plutus_data_unref(&placeholder);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    return result;
+  }
+
+  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
+  cardano_credential_unref(&credential);
+
+  cardano_blake2b_hash_t* hash = NULL;
+
+  result = compute_credential_sortable_id(credential, &hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to compute the withdrawal sortable id.";
+
+    return result;
+  }
+
+  result = cardano_builder_register_deferred_from_map(state, state->withdrawals_to_redeemer_map, hash, callback, user_context, error_message);
+
+  cardano_blake2b_hash_unref(&hash);
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_withdrawals.h
+++ b/lib/src/transaction_builder/internals/builder_withdrawals.h
@@ -1,0 +1,136 @@
+/**
+ * \file builder_withdrawals.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITHDRAWALS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITHDRAWALS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/address/reward_address.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Records a reward withdrawal in the transaction.
+ *
+ * This function inserts the withdrawal for \p address with the given amount into the withdrawal map
+ * of the transaction body, creating the map when it is missing. When \p redeemer is not NULL it is
+ * attached as a reward redeemer keyed by the sortable id of the reward credential in the state
+ * withdrawal redeemer map. When \p redeemer is NULL and the reward credential is a script credential
+ * the sortable id is still recorded in the map with a NULL redeemer so redeemer indices can be
+ * computed; script credentials are processed by the node before key hash credentials regardless of
+ * the canonical sorting, so key hash credentials are skipped.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t to withdraw from. This parameter
+ *                    must not be NULL.
+ * \param[in] amount The amount of lovelace to withdraw. It must not be negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as reward redeemer payload,
+ *                     or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the withdrawal was recorded, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_withdraw_rewards(
+  cardano_builder_state_t*  state,
+  cardano_reward_address_t* address,
+  int64_t                   amount,
+  cardano_plutus_data_t*    redeemer,
+  const char**              error_message);
+
+/**
+ * \brief Records a reward withdrawal given the reward address as a bech32 string.
+ *
+ * This function parses the reward address and delegates to \ref cardano_builder_withdraw_rewards.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] reward_address A pointer to the bech32 string with the reward address.
+ * \param[in] address_size The size of the reward address string in bytes.
+ * \param[in] amount The amount of lovelace to withdraw. It must not be negative.
+ * \param[in] redeemer A pointer to the \ref cardano_plutus_data_t used as reward redeemer payload,
+ *                     or NULL when the credential does not require one.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the withdrawal was recorded, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_withdraw_rewards_ex(
+  cardano_builder_state_t* state,
+  const char*              reward_address,
+  size_t                   address_size,
+  int64_t                  amount,
+  cardano_plutus_data_t*   redeemer,
+  const char**             error_message);
+
+/**
+ * \brief Records a reward withdrawal whose redeemer payload is resolved during balancing.
+ *
+ * This function records the withdrawal with an empty placeholder redeemer and registers the callback
+ * in the state deferred redeemer list keyed by the sortable id of the reward credential. The callback
+ * is invoked while the transaction is balanced to produce the final redeemer payload.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] address A pointer to the \ref cardano_reward_address_t to withdraw from. This parameter
+ *                    must not be NULL.
+ * \param[in] amount The amount of lovelace to withdraw. It must not be negative.
+ * \param[in] callback The deferred redeemer callback invoked during balancing. This parameter must
+ *                     not be NULL.
+ * \param[in] user_context The opaque pointer forwarded to the callback.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the withdrawal and callback were registered, or an appropriate
+ *         error code indicating the failure reason.
+ */
+cardano_error_t
+cardano_builder_withdraw_rewards_with_deferred_redeemer(
+  cardano_builder_state_t*       state,
+  cardano_reward_address_t*      address,
+  int64_t                        amount,
+  cardano_deferred_redeemer_fn_t callback,
+  void*                          user_context,
+  const char**                   error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITHDRAWALS_H

--- a/lib/src/transaction_builder/internals/builder_witnesses.c
+++ b/lib/src/transaction_builder/internals/builder_witnesses.c
@@ -1,0 +1,251 @@
+/**
+ * \file builder_witnesses.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "builder_witnesses.h"
+
+#include <cardano/common/credential.h>
+#include <cardano/common/guard_set.h>
+#include <cardano/transaction_body/transaction_body.h>
+#include <cardano/witness_set/plutus_data_set.h>
+#include <cardano/witness_set/witness_set.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_builder_pad_signer_count(
+  cardano_builder_state_t* state,
+  const size_t             count)
+{
+  state->additional_signature_count = count;
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_add_signer(
+  cardano_builder_state_t* state,
+  cardano_blake2b_hash_t*  pub_key_hash,
+  const char**             error_message)
+{
+  if (pub_key_hash == NULL)
+  {
+    *error_message = "Public key hash is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_transaction_body_t* body = cardano_transaction_get_body(state->transaction);
+  cardano_transaction_body_unref(&body);
+
+  cardano_guard_set_t* guards = cardano_transaction_body_get_guards(body);
+
+  if (guards == NULL)
+  {
+    cardano_error_t result = cardano_guard_set_new(&guards);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create guards set.";
+
+      return result;
+    }
+
+    result = cardano_transaction_body_set_guards(body, guards);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set guards set.";
+      cardano_guard_set_unref(&guards);
+
+      return result;
+    }
+  }
+
+  cardano_guard_set_unref(&guards);
+
+  cardano_credential_t* credential = NULL;
+  cardano_error_t       result     = cardano_credential_new(pub_key_hash, CARDANO_CREDENTIAL_TYPE_KEY_HASH, &credential);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to create signer credential.";
+
+    return result;
+  }
+
+  result = cardano_guard_set_add(guards, credential);
+
+  cardano_credential_unref(&credential);
+
+  if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
+  {
+    *error_message = "Failed to add signer.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_add_signer_ex(
+  cardano_builder_state_t* state,
+  const char*              pub_key_hash,
+  size_t                   hash_size,
+  const char**             error_message)
+{
+  if ((pub_key_hash == NULL) || (hash_size == 0U))
+  {
+    *error_message = "Public key hash is NULL or empty.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_blake2b_hash_t* hash   = NULL;
+  cardano_error_t         result = cardano_blake2b_hash_from_hex(pub_key_hash, hash_size, &hash);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to parse public key hash.";
+
+    return result;
+  }
+
+  result = cardano_builder_add_signer(state, hash, error_message);
+  cardano_blake2b_hash_unref(&hash);
+
+  return result;
+}
+
+cardano_error_t
+cardano_builder_add_datum(
+  cardano_builder_state_t* state,
+  cardano_plutus_data_t*   datum,
+  const char**             error_message)
+{
+  if (datum == NULL)
+  {
+    *error_message = "Datum is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witness_set);
+
+  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witness_set);
+
+  if (datums == NULL)
+  {
+    cardano_error_t result = cardano_plutus_data_set_new(&datums);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to create datums set.";
+
+      return result;
+    }
+
+    result = cardano_witness_set_set_plutus_data(witness_set, datums);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      *error_message = "Failed to set datums set.";
+      cardano_plutus_data_set_unref(&datums);
+
+      return result;
+    }
+  }
+
+  cardano_plutus_data_set_unref(&datums);
+
+  cardano_error_t result = cardano_plutus_data_set_add(datums, datum);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add datum.";
+
+    return result;
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_builder_add_script(
+  cardano_builder_state_t* state,
+  cardano_script_t*        script,
+  const char**             error_message)
+{
+  if (script == NULL)
+  {
+    *error_message = "Script is NULL.";
+
+    return CARDANO_ERROR_POINTER_IS_NULL;
+  }
+
+  cardano_script_language_t language;
+  cardano_error_t           result = cardano_script_get_language(script, &language);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to get script language.";
+
+    return result;
+  }
+
+  switch (language)
+  {
+    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
+    {
+      state->has_plutus_v1 = true;
+      break;
+    }
+    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
+    {
+      state->has_plutus_v2 = true;
+      break;
+    }
+    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
+    {
+      state->has_plutus_v3 = true;
+      break;
+    }
+    default:
+    {
+      break;
+    }
+  }
+
+  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(state->transaction);
+  cardano_witness_set_unref(&witness_set);
+
+  result = cardano_witness_set_add_script(witness_set, script);
+
+  if (result != CARDANO_SUCCESS)
+  {
+    *error_message = "Failed to add script to witness set.";
+  }
+
+  return result;
+}

--- a/lib/src/transaction_builder/internals/builder_witnesses.h
+++ b/lib/src/transaction_builder/internals/builder_witnesses.h
@@ -1,0 +1,153 @@
+/**
+ * \file builder_witnesses.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITNESSES_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITNESSES_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/plutus_data/plutus_data.h>
+#include <cardano/scripts/script.h>
+
+#include "builder_state.h"
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Sets the number of additional signatures accounted for when computing fees.
+ *
+ * This function stores \p count in the state so that balancing reserves fee room for that many
+ * signatures beyond the ones the builder can infer from the transaction.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] count The number of additional signatures to account for.
+ *
+ * \return \ref CARDANO_SUCCESS.
+ */
+cardano_error_t
+cardano_builder_pad_signer_count(
+  cardano_builder_state_t* state,
+  size_t                   count);
+
+/**
+ * \brief Adds a required signer to the transaction.
+ *
+ * This function adds the key hash credential of \p pub_key_hash to the guard set of the transaction
+ * body, creating the set when it is missing. Adding a signer that is already present leaves the
+ * transaction unchanged and succeeds.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] pub_key_hash A pointer to the \ref cardano_blake2b_hash_t with the public key hash of
+ *                         the signer. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the signer was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_signer(
+  cardano_builder_state_t* state,
+  cardano_blake2b_hash_t*  pub_key_hash,
+  const char**             error_message);
+
+/**
+ * \brief Adds a required signer given the public key hash as a hexadecimal string.
+ *
+ * This function parses the public key hash and delegates to \ref cardano_builder_add_signer.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] pub_key_hash A pointer to the hexadecimal string with the public key hash.
+ * \param[in] hash_size The size of the public key hash string in bytes.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the signer was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_signer_ex(
+  cardano_builder_state_t* state,
+  const char*              pub_key_hash,
+  size_t                   hash_size,
+  const char**             error_message);
+
+/**
+ * \brief Adds a datum to the witness set.
+ *
+ * This function appends \p datum to the plutus data set of the witness set, creating the set when it
+ * is missing.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] datum A pointer to the \ref cardano_plutus_data_t to add. This parameter must not be
+ *                  NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the datum was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_datum(
+  cardano_builder_state_t* state,
+  cardano_plutus_data_t*   datum,
+  const char**             error_message);
+
+/**
+ * \brief Adds a script to the witness set.
+ *
+ * This function adds \p script to the witness set of the transaction under construction and flags
+ * the Plutus language version of the script in the state when it is a Plutus script.
+ *
+ * \param[in,out] state A pointer to the \ref cardano_builder_state_t tracking the transaction under
+ *                      construction. This parameter must not be NULL.
+ * \param[in] script A pointer to the \ref cardano_script_t to add. This parameter must not be NULL.
+ * \param[out] error_message A pointer that receives a static string describing the failure when the
+ *                           function does not return \ref CARDANO_SUCCESS. It is left untouched on
+ *                           success. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the script was added, or an appropriate error code indicating the
+ *         failure reason.
+ */
+cardano_error_t
+cardano_builder_add_script(
+  cardano_builder_state_t* state,
+  cardano_script_t*        script,
+  const char**             error_message);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BUILDER_WITNESSES_H

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -26,7 +26,6 @@
 #include <cardano/object.h>
 
 #include "../allocators.h"
-#include "./internals/blake2b_hash_to_redeemer_map.h"
 #include "./internals/builder_build.h"
 #include "./internals/builder_certs.h"
 #include "./internals/builder_config.h"

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -24,15 +24,12 @@
 #include <cardano/transaction_builder/transaction_builder.h>
 
 #include <cardano/object.h>
-#include <cardano/time.h>
-#include <cardano/transaction_builder/balancing/input_to_redeemer_map.h>
-#include <cardano/transaction_builder/balancing/transaction_balancing.h>
-#include <cardano/transaction_builder/script_data_hash.h>
-#include <cardano/witness_set/redeemer.h>
 
 #include "../allocators.h"
 #include "./internals/blake2b_hash_to_redeemer_map.h"
+#include "./internals/builder_build.h"
 #include "./internals/builder_certs.h"
+#include "./internals/builder_config.h"
 #include "./internals/builder_inputs.h"
 #include "./internals/builder_mint.h"
 #include "./internals/builder_outputs.h"
@@ -41,6 +38,7 @@
 #include "./internals/builder_state.h"
 #include "./internals/builder_votes.h"
 #include "./internals/builder_withdrawals.h"
+#include "./internals/builder_witnesses.h"
 
 #include <assert.h>
 
@@ -121,215 +119,6 @@ track_builder_result(
   }
 }
 
-/**
- * \brief Sets a dummy script data hash in the transaction.
- *
- * This function assigns a placeholder script data hash to the specified transaction for fee calculation
- * purposes when the transaction includes script data.
- *
- * \param[in,out] tx A pointer to a \ref cardano_transaction_t object representing the transaction to which
- *                   the dummy script data hash will be set. This parameter must not be NULL.
- *
- * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the dummy
- *         script data hash was successfully set, or an appropriate error code indicating the failure reason.
- */
-static cardano_error_t
-set_dummy_script_data_hash(cardano_transaction_t* tx)
-{
-  if (!cardano_transaction_has_script_data(tx))
-  {
-    return CARDANO_SUCCESS;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx);
-  cardano_transaction_body_unref(&body);
-
-  static byte_t           dummy_hash[32] = { 0 };
-  cardano_blake2b_hash_t* hash           = NULL;
-
-  cardano_error_t new_hash_result = cardano_blake2b_hash_from_bytes(dummy_hash, sizeof(dummy_hash), &hash);
-
-  if (new_hash_result != CARDANO_SUCCESS)
-  {
-    return new_hash_result;
-  }
-
-  new_hash_result = cardano_transaction_body_set_script_data_hash(body, hash);
-  cardano_blake2b_hash_unref(&hash);
-
-  if (new_hash_result != CARDANO_SUCCESS)
-  {
-    return new_hash_result;
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Retrieves the cost model for a specified Plutus language version.
- *
- * This function searches for the cost model matching the specified Plutus language version within a
- * provided set of source cost models and, if found, copies it into a destination cost model set.
- *
- * \param[in] source_models A pointer to the \ref cardano_costmdls_t object containing the source cost models.
- * \param[out] dest_models A pointer to the \ref cardano_costmdls_t object where the matching cost model
- *                         for the specified version will be copied. This parameter must not be NULL.
- * \param[in] version The Plutus language version of the cost model to retrieve.
- *
- * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the cost model
- *         was successfully found and copied, or an appropriate error code if an internal error occurs.
- */
-static cardano_error_t
-get_cost_model_for_version(
-  cardano_costmdls_t*                     source_models,
-  cardano_costmdls_t*                     dest_models,
-  const cardano_plutus_language_version_t version)
-{
-  assert(source_models != NULL);
-  assert(dest_models != NULL);
-
-  cardano_cost_model_t* cost_model = NULL;
-
-  cardano_error_t result = cardano_costmdls_get(source_models, version, &cost_model);
-  cardano_cost_model_unref(&cost_model);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  result = cardano_costmdls_insert(dest_models, cost_model);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Retrieves the cost models flagged by the the transaction builder.
- *
- * \param[in] builder A pointer to the \ref cardano_tx_builder_t instance from which the cost models will be retrieved.
- * \param[out] costmdls A pointer to an initialized \ref cardano_costmdls_t object where the cost models will be stored.
- *                      This parameter must not be NULL.
- *
- * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS if the cost models
- *         were successfully retrieved and stored, or an appropriate error code if an error occurs during retrieval.
- */
-static cardano_error_t
-get_cost_models(cardano_tx_builder_t* builder, cardano_costmdls_t* costmdls)
-{
-  cardano_costmdls_t* pparams_costmdls = cardano_protocol_parameters_get_cost_models(builder->state.params);
-  cardano_costmdls_unref(&pparams_costmdls);
-
-  cardano_error_t result = CARDANO_SUCCESS;
-
-  if (builder->state.has_plutus_v1)
-  {
-    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V1);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  if (builder->state.has_plutus_v2)
-  {
-    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V2);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  if (builder->state.has_plutus_v3)
-  {
-    result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V3);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return result;
-}
-
-/**
- * \brief Computes and updates the script data hash in a transaction.
- *
- * This function calculates the script data hash based on the redeemers, datums, and cost models
- * associated with the transaction in the \ref cardano_tx_builder_t instance, then updates this
- * hash in the provided \ref cardano_transaction_t.
- *
- * \param[in] builder A pointer to the \ref cardano_tx_builder_t instance containing the necessary
- *                    transaction data, including redeemers, datums, and cost models.
- * \param[in,out] tx A pointer to an initialized \ref cardano_transaction_t object. This transaction
- *                   will be updated with the computed script data hash.
- *
- * \return \ref cardano_error_t indicating the result of the operation. Returns \ref CARDANO_SUCCESS
- *         if the script data hash was successfully computed and updated in the transaction, or an
- *         appropriate error code if the computation or update fails.
- */
-static cardano_error_t
-update_script_data_hash(cardano_tx_builder_t* builder, cardano_transaction_t* tx)
-{
-  if (!cardano_transaction_has_script_data(tx))
-  {
-    return CARDANO_SUCCESS;
-  }
-
-  cardano_costmdls_t* costmdls = NULL;
-
-  cardano_error_t result = cardano_costmdls_new(&costmdls);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  result = get_cost_models(builder, costmdls);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_costmdls_unref(&costmdls);
-    return result;
-  }
-
-  cardano_blake2b_hash_t* hash = NULL;
-
-  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(tx);
-  cardano_witness_set_unref(&witness_set);
-
-  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witness_set);
-  cardano_redeemer_list_unref(&redeemers);
-
-  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witness_set);
-  cardano_plutus_data_set_unref(&datums);
-
-  result = cardano_compute_script_data_hash(costmdls, redeemers, datums, &hash);
-  cardano_costmdls_unref(&costmdls);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_blake2b_hash_unref(&hash);
-
-    return result;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx);
-  cardano_transaction_body_unref(&body);
-
-  result = cardano_transaction_body_set_script_data_hash(body, hash);
-  cardano_blake2b_hash_unref(&hash);
-
-  return result;
-}
-
 /* DEFINITIONS ****************************************************************/
 
 cardano_tx_builder_t*
@@ -376,16 +165,11 @@ cardano_tx_builder_set_coin_selector(
     return;
   }
 
-  if (coin_selector == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Coin selector is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_coin_selector_ref(coin_selector);
-  cardano_coin_selector_unref(&builder->state.coin_selector);
-  builder->state.coin_selector = coin_selector;
+  const cardano_error_t result = cardano_builder_set_coin_selector(&builder->state, coin_selector, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -398,16 +182,11 @@ cardano_tx_builder_set_tx_evaluator(
     return;
   }
 
-  if (tx_evaluator == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction evaluator is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_tx_evaluator_ref(tx_evaluator);
-  cardano_tx_evaluator_unref(&builder->state.tx_evaluator);
-  builder->state.tx_evaluator = tx_evaluator;
+  const cardano_error_t result = cardano_builder_set_tx_evaluator(&builder->state, tx_evaluator, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -420,24 +199,11 @@ cardano_tx_builder_set_network_id(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_network_id(&builder->state, network_id, &error_message);
 
-    return;
-  }
-
-  cardano_error_t result = cardano_transaction_body_set_network_id(body, &network_id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set network ID.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -450,16 +216,11 @@ cardano_tx_builder_set_change_address(
     return;
   }
 
-  if (change_address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Change address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_ref(change_address);
-  cardano_address_unref(&builder->state.change_address);
-  builder->state.change_address = change_address;
+  const cardano_error_t result = cardano_builder_set_change_address(&builder->state, change_address, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -473,25 +234,11 @@ cardano_tx_builder_set_change_address_ex(
     return;
   }
 
-  if ((change_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Change address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_t* address = NULL;
-  cardano_error_t    result  = cardano_address_from_string(change_address, address_size, &address);
+  const cardano_error_t result = cardano_builder_set_change_address_ex(&builder->state, change_address, address_size, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse change address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_set_change_address(builder, address);
-  cardano_address_unref(&address);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -504,16 +251,11 @@ cardano_tx_builder_set_collateral_change_address(
     return;
   }
 
-  if (collateral_change_address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Collateral change address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_ref(collateral_change_address);
-  cardano_address_unref(&builder->state.collateral_address);
-  builder->state.collateral_address = collateral_change_address;
+  const cardano_error_t result = cardano_builder_set_collateral_change_address(&builder->state, collateral_change_address, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -527,25 +269,11 @@ cardano_tx_builder_set_collateral_change_address_ex(
     return;
   }
 
-  if ((collateral_change_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Collateral change address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_t* address = NULL;
-  cardano_error_t    result  = cardano_address_from_string(collateral_change_address, address_size, &address);
+  const cardano_error_t result = cardano_builder_set_collateral_change_address_ex(&builder->state, collateral_change_address, address_size, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse collateral change address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_set_collateral_change_address(builder, address);
-  cardano_address_unref(&address);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -558,24 +286,11 @@ cardano_tx_builder_set_minimum_fee(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_minimum_fee(&builder->state, minimum_fee, &error_message);
 
-    return;
-  }
-
-  cardano_error_t result = cardano_transaction_body_set_fee(body, minimum_fee);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set fee.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -588,33 +303,11 @@ cardano_tx_builder_set_donation(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_donation(&builder->state, donation, &error_message);
 
-    return;
-  }
-
-  cardano_error_t result = CARDANO_SUCCESS;
-
-  if (donation == 0U)
-  {
-    result = cardano_transaction_body_set_donation(body, NULL);
-  }
-  else
-  {
-    result = cardano_transaction_body_set_donation(body, &donation);
-  }
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set donation.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -627,16 +320,11 @@ cardano_tx_builder_set_utxos(
     return;
   }
 
-  if (utxos == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "UTXOs list is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_utxo_list_ref(utxos);
-  cardano_utxo_list_unref(&builder->state.available_utxos);
-  builder->state.available_utxos = utxos;
+  const cardano_error_t result = cardano_builder_set_utxos(&builder->state, utxos, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -649,16 +337,11 @@ cardano_tx_builder_set_collateral_utxos(
     return;
   }
 
-  if (utxos == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Collateral UTXOs list is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_utxo_list_ref(utxos);
-  cardano_utxo_list_unref(&builder->state.collateral_utxos);
-  builder->state.collateral_utxos = utxos;
+  const cardano_error_t result = cardano_builder_set_collateral_utxos(&builder->state, utxos, &error_message);
+
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -671,24 +354,11 @@ cardano_tx_builder_set_invalid_after(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_invalid_after(&builder->state, slot, &error_message);
 
-    return;
-  }
-
-  cardano_error_t result = cardano_transaction_body_set_invalid_after(body, &slot);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set invalid after.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -701,25 +371,11 @@ cardano_tx_builder_set_invalid_after_ex(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_invalid_after_ex(&builder->state, unix_time, &error_message);
 
-    return;
-  }
-
-  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->state.slot_config);
-  cardano_error_t result = cardano_transaction_body_set_invalid_after(body, &slot);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set invalid after.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -732,24 +388,11 @@ cardano_tx_builder_set_invalid_before(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_invalid_before(&builder->state, slot, &error_message);
 
-    return;
-  }
-
-  cardano_error_t result = cardano_transaction_body_set_invalid_before(body, &slot);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set invalid before.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -762,25 +405,11 @@ cardano_tx_builder_set_invalid_before_ex(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const char* error_message = NULL;
 
-  if (body == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Transaction body is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const cardano_error_t result = cardano_builder_set_invalid_before_ex(&builder->state, unix_time, &error_message);
 
-    return;
-  }
-
-  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->state.slot_config);
-  cardano_error_t result = cardano_transaction_body_set_invalid_before(body, &slot);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set invalid before.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -997,88 +626,11 @@ cardano_tx_builder_set_metadata(
     return;
   }
 
-  if (metadata == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_auxiliary_data_t* auxiliary_data = cardano_transaction_get_auxiliary_data(builder->state.transaction);
+  const cardano_error_t result = cardano_builder_set_metadata(&builder->state, tag, metadata, &error_message);
 
-  if (auxiliary_data == NULL)
-  {
-    cardano_error_t result = cardano_auxiliary_data_new(&auxiliary_data);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create auxiliary data.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_transaction_set_auxiliary_data(builder->state.transaction, auxiliary_data);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set auxiliary data.");
-      cardano_auxiliary_data_unref(&auxiliary_data);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_auxiliary_data_unref(&auxiliary_data);
-
-  cardano_transaction_metadata_t* tx_metadata = cardano_auxiliary_data_get_transaction_metadata(auxiliary_data);
-
-  if (tx_metadata == NULL)
-  {
-    cardano_error_t result = cardano_transaction_metadata_new(&tx_metadata);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create transaction metadata.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_auxiliary_data_set_transaction_metadata(auxiliary_data, tx_metadata);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set transaction metadata.");
-      cardano_transaction_metadata_unref(&tx_metadata);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_transaction_metadata_unref(&tx_metadata);
-
-  cardano_error_t result = cardano_transaction_metadata_insert(tx_metadata, tag, metadata);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to insert metadata.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_blake2b_hash_t* hash = cardano_auxiliary_data_get_hash(auxiliary_data);
-
-  result = cardano_transaction_body_set_aux_data_hash(body, hash);
-  cardano_blake2b_hash_unref(&hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set auxiliary data hash.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1093,25 +645,11 @@ cardano_tx_builder_set_metadata_ex(
     return;
   }
 
-  if ((metadata_json == NULL) || (json_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_metadatum_t* metadata = NULL;
-  cardano_error_t      result   = cardano_metadatum_from_json(metadata_json, json_size, &metadata);
+  const cardano_error_t result = cardano_builder_set_metadata_ex(&builder->state, tag, metadata_json, json_size, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse metadata.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_set_metadata(builder, tag, metadata);
-  cardano_metadatum_unref(&metadata);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1205,7 +743,9 @@ cardano_tx_builder_pad_signer_count(
     return;
   }
 
-  builder->state.additional_signature_count = count;
+  const cardano_error_t result = cardano_builder_pad_signer_count(&builder->state, count);
+
+  track_builder_result(builder, result, NULL);
 }
 
 void
@@ -1218,66 +758,11 @@ cardano_tx_builder_add_signer(
     return;
   }
 
-  if (pub_key_hash == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Public key hash is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_signer(&builder->state, pub_key_hash, &error_message);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_guard_set_t* guards = cardano_transaction_body_get_guards(body);
-
-  if (guards == NULL)
-  {
-    cardano_error_t result = cardano_guard_set_new(&guards);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create guards set.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    result = cardano_transaction_body_set_guards(body, guards);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set guards set.");
-      cardano_guard_set_unref(&guards);
-
-      builder->last_error = result;
-
-      return;
-    }
-  }
-
-  cardano_guard_set_unref(&guards);
-
-  cardano_credential_t* credential = NULL;
-  cardano_error_t       result     = cardano_credential_new(pub_key_hash, CARDANO_CREDENTIAL_TYPE_KEY_HASH, &credential);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create signer credential.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  result = cardano_guard_set_add(guards, credential);
-
-  cardano_credential_unref(&credential);
-
-  if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add signer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1291,27 +776,11 @@ cardano_tx_builder_add_signer_ex(
     return;
   }
 
-  if ((pub_key_hash == NULL) || (hash_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Public key hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_signer_ex(&builder->state, pub_key_hash, hash_size, &error_message);
 
-  cardano_blake2b_hash_t* hash   = NULL;
-  cardano_error_t         result = cardano_blake2b_hash_from_hex(pub_key_hash, hash_size, &hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse public key hash.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_add_signer(builder, hash);
-  cardano_blake2b_hash_unref(&hash);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1324,55 +793,11 @@ cardano_tx_builder_add_datum(
     return;
   }
 
-  if (datum == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Datum is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_datum(&builder->state, datum, &error_message);
 
-  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witness_set);
-
-  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witness_set);
-
-  if (datums == NULL)
-  {
-    cardano_error_t result = cardano_plutus_data_set_new(&datums);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create datums set.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    result = cardano_witness_set_set_plutus_data(witness_set, datums);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set datums set.");
-      cardano_plutus_data_set_unref(&datums);
-
-      builder->last_error = result;
-
-      return;
-    }
-  }
-
-  cardano_plutus_data_set_unref(&datums);
-
-  cardano_error_t result = cardano_plutus_data_set_add(datums, datum);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add datum.");
-    builder->last_error = result;
-
-    return;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1737,58 +1162,11 @@ cardano_tx_builder_add_script(
     return;
   }
 
-  if (script == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Script is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_script(&builder->state, script, &error_message);
 
-  cardano_script_language_t language;
-  cardano_error_t           result = cardano_script_get_language(script, &language);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to get script language.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  switch (language)
-  {
-    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
-    {
-      builder->state.has_plutus_v1 = true;
-      break;
-    }
-    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
-    {
-      builder->state.has_plutus_v2 = true;
-      break;
-    }
-    case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
-    {
-      builder->state.has_plutus_v3 = true;
-      break;
-    }
-    default:
-    {
-      break;
-    }
-  }
-
-  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witness_set);
-
-  result = cardano_witness_set_add_script(witness_set, script);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add script to witness set.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2127,96 +1505,17 @@ cardano_tx_builder_build(
     return builder->last_error;
   }
 
-  if (builder->state.change_address == NULL)
-  {
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    cardano_tx_builder_set_last_error(
-      builder,
-      "You must set a change address before calling `build`.");
+  const char* error_message = NULL;
 
-    return builder->last_error;
-  }
-
-  if (builder->state.available_utxos == NULL)
-  {
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    cardano_tx_builder_set_last_error(
-      builder,
-      "You must set the available UTXOs for input selection before calling `build`.");
-
-    return builder->last_error;
-  }
-
-  if (cardano_transaction_has_script_data(builder->state.transaction))
-  {
-    if (builder->state.collateral_address == NULL)
-    {
-      builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-      cardano_tx_builder_set_last_error(
-        builder,
-        "This transaction interacts with plutus validators. You must set a collateral change address before calling `build`.");
-
-      return builder->last_error;
-    }
-
-    if (builder->state.collateral_utxos == NULL)
-    {
-      builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-      cardano_tx_builder_set_last_error(
-        builder,
-        "This transaction interacts with plutus validators. You must set the collateral UTXOs before calling `build`.");
-
-      return builder->last_error;
-    }
-  }
-
-  cardano_transaction_t* tx = builder->state.transaction;
-
-  cardano_error_t result = set_dummy_script_data_hash(tx);
+  const cardano_error_t result = cardano_builder_build(&builder->state, transaction, &error_message);
 
   if (result != CARDANO_SUCCESS)
   {
-    builder->last_error = result;
-    return result;
-  }
-
-  result = cardano_balance_transaction(
-    tx,
-    builder->state.additional_signature_count,
-    builder->state.params,
-    builder->state.reference_inputs,
-    builder->state.pre_selected_inputs,
-    builder->state.input_to_redeemer_map,
-    builder->state.available_utxos,
-    builder->state.coin_selector,
-    builder->state.change_address,
-    builder->state.collateral_utxos,
-    builder->state.collateral_address,
-    builder->state.tx_evaluator,
-    builder->state.deferred_redeemers);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    builder->last_error = result;
-    cardano_tx_builder_set_last_error(
-      builder,
-      cardano_transaction_get_last_error(tx));
+    track_builder_result(builder, result, error_message);
 
     return result;
   }
 
-  result = update_script_data_hash(builder, tx);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    builder->last_error = result;
-    return result;
-  }
-
-  cardano_transaction_ref(tx);
-  *transaction = tx;
-
-  // Build method can only be called once
   builder->last_error = CARDANO_ERROR_ILLEGAL_STATE;
 
   return CARDANO_SUCCESS;

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -29,13 +29,12 @@
 #include <cardano/time.h>
 #include <cardano/transaction_builder/balancing/input_to_redeemer_map.h>
 #include <cardano/transaction_builder/balancing/transaction_balancing.h>
-#include <cardano/transaction_builder/coin_selection/random_improve_coin_selector.h>
-#include <cardano/transaction_builder/evaluation/native_tx_evaluator.h>
 #include <cardano/transaction_builder/script_data_hash.h>
 #include <cardano/witness_set/redeemer.h>
 
 #include "../allocators.h"
 #include "./internals/blake2b_hash_to_redeemer_map.h"
+#include "./internals/builder_state.h"
 
 #include <assert.h>
 #include <cardano/certs/register_drep_cert.h>
@@ -71,30 +70,9 @@
  */
 typedef struct cardano_tx_builder_t
 {
-    cardano_object_t               base;
-    cardano_error_t                last_error;
-    cardano_transaction_t*         transaction;
-    cardano_protocol_parameters_t* params;
-    cardano_slot_config_t          slot_config;
-    cardano_coin_selector_t*       coin_selector;
-    cardano_tx_evaluator_t*        tx_evaluator;
-    cardano_address_t*             change_address;
-    cardano_address_t*             collateral_address;
-    cardano_utxo_list_t*           available_utxos;
-    cardano_utxo_list_t*           collateral_utxos;
-    cardano_utxo_list_t*           pre_selected_inputs;
-    cardano_utxo_list_t*           reference_inputs;
-    bool                           has_plutus_v1;
-    bool                           has_plutus_v2;
-    bool                           has_plutus_v3;
-    size_t                         additional_signature_count;
-
-    // Redeemer maps
-    cardano_input_to_redeemer_map_t*        input_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* withdrawals_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* mints_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* votes_to_redeemer_map;
-    cardano_deferred_redeemer_list_t*       deferred_redeemers;
+    cardano_object_t        base;
+    cardano_error_t         last_error;
+    cardano_builder_state_t state;
 } cardano_tx_builder_t;
 
 /* STATIC DECLARATIONS *******************************************************/
@@ -119,94 +97,9 @@ cardano_tx_builder_deallocate(void* object)
 
   cardano_tx_builder_t* builder = (cardano_tx_builder_t*)object;
 
-  cardano_transaction_unref(&builder->transaction);
-  cardano_protocol_parameters_unref(&builder->params);
-  cardano_coin_selector_unref(&builder->coin_selector);
-  cardano_tx_evaluator_unref(&builder->tx_evaluator);
-  cardano_address_unref(&builder->change_address);
-  cardano_address_unref(&builder->collateral_address);
-  cardano_utxo_list_unref(&builder->available_utxos);
-  cardano_utxo_list_unref(&builder->collateral_utxos);
-  cardano_utxo_list_unref(&builder->pre_selected_inputs);
-  cardano_utxo_list_unref(&builder->reference_inputs);
-  cardano_input_to_redeemer_map_unref(&builder->input_to_redeemer_map);
-  cardano_blake2b_hash_to_redeemer_map_unref(&builder->withdrawals_to_redeemer_map);
-  cardano_blake2b_hash_to_redeemer_map_unref(&builder->mints_to_redeemer_map);
-  cardano_blake2b_hash_to_redeemer_map_unref(&builder->votes_to_redeemer_map);
-  cardano_deferred_redeemer_list_unref(&builder->deferred_redeemers);
+  cardano_builder_state_release(&builder->state);
 
   _cardano_free(builder);
-}
-
-/**
- * \brief Creates and initializes a new, empty transaction.
- *
- * This function allocates and initializes a new instance of a \ref cardano_transaction_t object.
- *
- * \return A pointer to the newly created \ref cardano_transaction_t object if successful. Returns
- * \c NULL if memory allocation fails.
- */
-static cardano_transaction_t*
-transaction_new(void)
-{
-  cardano_transaction_body_t*        body        = NULL;
-  cardano_transaction_input_set_t*   inputs      = NULL;
-  cardano_transaction_output_list_t* outputs     = NULL;
-  cardano_witness_set_t*             witnesses   = NULL;
-  cardano_transaction_t*             transaction = NULL;
-
-  cardano_error_t result = cardano_transaction_input_set_new(&inputs);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return NULL;
-  }
-
-  result = cardano_transaction_output_list_new(&outputs);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_transaction_input_set_unref(&inputs);
-    return NULL;
-  }
-
-  result = cardano_transaction_body_new(inputs, outputs, 0U, NULL, &body);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_transaction_input_set_unref(&inputs);
-    cardano_transaction_output_list_unref(&outputs);
-    return NULL;
-  }
-
-  result = cardano_witness_set_new(&witnesses);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_transaction_input_set_unref(&inputs);
-    cardano_transaction_output_list_unref(&outputs);
-    cardano_transaction_body_unref(&body);
-    return NULL;
-  }
-
-  result = cardano_transaction_new(body, witnesses, NULL, &transaction);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_transaction_input_set_unref(&inputs);
-    cardano_transaction_output_list_unref(&outputs);
-    cardano_transaction_body_unref(&body);
-    cardano_witness_set_unref(&witnesses);
-
-    return NULL;
-  }
-
-  cardano_transaction_input_set_unref(&inputs);
-  cardano_transaction_output_list_unref(&outputs);
-  cardano_transaction_body_unref(&body);
-  cardano_witness_set_unref(&witnesses);
-
-  return transaction;
 }
 
 /**
@@ -309,12 +202,12 @@ get_cost_model_for_version(
 static cardano_error_t
 get_cost_models(cardano_tx_builder_t* builder, cardano_costmdls_t* costmdls)
 {
-  cardano_costmdls_t* pparams_costmdls = cardano_protocol_parameters_get_cost_models(builder->params);
+  cardano_costmdls_t* pparams_costmdls = cardano_protocol_parameters_get_cost_models(builder->state.params);
   cardano_costmdls_unref(&pparams_costmdls);
 
   cardano_error_t result = CARDANO_SUCCESS;
 
-  if (builder->has_plutus_v1)
+  if (builder->state.has_plutus_v1)
   {
     result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V1);
 
@@ -324,7 +217,7 @@ get_cost_models(cardano_tx_builder_t* builder, cardano_costmdls_t* costmdls)
     }
   }
 
-  if (builder->has_plutus_v2)
+  if (builder->state.has_plutus_v2)
   {
     result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V2);
 
@@ -334,7 +227,7 @@ get_cost_models(cardano_tx_builder_t* builder, cardano_costmdls_t* costmdls)
     }
   }
 
-  if (builder->has_plutus_v3)
+  if (builder->state.has_plutus_v3)
   {
     result = get_cost_model_for_version(pparams_costmdls, costmdls, CARDANO_PLUTUS_LANGUAGE_VERSION_V3);
 
@@ -487,7 +380,7 @@ add_redeemer(
     {
       case CARDANO_REDEEMER_TAG_MINT:
       {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->mints_to_redeemer_map, hash, rdmer);
+        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.mints_to_redeemer_map, hash, rdmer);
 
         if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
         {
@@ -509,7 +402,7 @@ add_redeemer(
       }
       case CARDANO_REDEEMER_TAG_REWARD:
       {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->withdrawals_to_redeemer_map, hash, rdmer);
+        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.withdrawals_to_redeemer_map, hash, rdmer);
 
         if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
         {
@@ -531,7 +424,7 @@ add_redeemer(
       }
       case CARDANO_REDEEMER_TAG_VOTING:
       {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->votes_to_redeemer_map, hash, rdmer);
+        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.votes_to_redeemer_map, hash, rdmer);
 
         if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
         {
@@ -882,119 +775,9 @@ cardano_tx_builder_new(
   builder->base.last_error[0] = '\0';
   builder->base.deallocator   = cardano_tx_builder_deallocate;
 
-  builder->last_error                  = CARDANO_SUCCESS;
-  builder->transaction                 = NULL;
-  builder->params                      = NULL;
-  builder->slot_config                 = *slot_config;
-  builder->coin_selector               = NULL;
-  builder->tx_evaluator                = NULL;
-  builder->change_address              = NULL;
-  builder->collateral_address          = NULL;
-  builder->available_utxos             = NULL;
-  builder->collateral_utxos            = NULL;
-  builder->pre_selected_inputs         = NULL;
-  builder->reference_inputs            = NULL;
-  builder->input_to_redeemer_map       = NULL;
-  builder->withdrawals_to_redeemer_map = NULL;
-  builder->mints_to_redeemer_map       = NULL;
-  builder->votes_to_redeemer_map       = NULL;
-  builder->deferred_redeemers          = NULL;
-  builder->tx_evaluator                = NULL;
+  builder->last_error = CARDANO_SUCCESS;
 
-  cardano_protocol_parameters_ref(params);
-  builder->params = params;
-
-  cardano_error_t result = cardano_random_improve_coin_selector_new(&builder->coin_selector);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  builder->transaction = transaction_new();
-
-  if (builder->transaction == NULL)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  builder->change_address             = NULL;
-  builder->collateral_address         = NULL;
-  builder->available_utxos            = NULL;
-  builder->collateral_utxos           = NULL;
-  builder->pre_selected_inputs        = NULL;
-  builder->reference_inputs           = NULL;
-  builder->has_plutus_v1              = false;
-  builder->has_plutus_v2              = false;
-  builder->has_plutus_v3              = false;
-  builder->additional_signature_count = 0U;
-
-  result = cardano_utxo_list_new(&builder->pre_selected_inputs);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_utxo_list_new(&builder->reference_inputs);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_input_to_redeemer_map_new(&builder->input_to_redeemer_map);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_blake2b_hash_to_redeemer_map_new(&builder->withdrawals_to_redeemer_map);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_blake2b_hash_to_redeemer_map_new(&builder->mints_to_redeemer_map);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_blake2b_hash_to_redeemer_map_new(&builder->votes_to_redeemer_map);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  result = cardano_deferred_redeemer_list_new(&builder->deferred_redeemers);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_unref(&builder);
-    return NULL;
-  }
-
-  cardano_costmdls_t*         cost_models    = cardano_protocol_parameters_get_cost_models(builder->params);
-  cardano_protocol_version_t* version        = cardano_protocol_parameters_get_protocol_version(builder->params);
-  const uint64_t              protocol_major = cardano_protocol_version_get_major(version);
-
-  result = cardano_tx_evaluator_new_native(&builder->slot_config, cost_models, protocol_major, &builder->tx_evaluator);
-
-  cardano_costmdls_unref(&cost_models);
-  cardano_protocol_version_unref(&version);
+  const cardano_error_t result = cardano_builder_state_init(&builder->state, params, slot_config);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -1023,8 +806,8 @@ cardano_tx_builder_set_coin_selector(
   }
 
   cardano_coin_selector_ref(coin_selector);
-  cardano_coin_selector_unref(&builder->coin_selector);
-  builder->coin_selector = coin_selector;
+  cardano_coin_selector_unref(&builder->state.coin_selector);
+  builder->state.coin_selector = coin_selector;
 }
 
 void
@@ -1045,8 +828,8 @@ cardano_tx_builder_set_tx_evaluator(
   }
 
   cardano_tx_evaluator_ref(tx_evaluator);
-  cardano_tx_evaluator_unref(&builder->tx_evaluator);
-  builder->tx_evaluator = tx_evaluator;
+  cardano_tx_evaluator_unref(&builder->state.tx_evaluator);
+  builder->state.tx_evaluator = tx_evaluator;
 }
 
 void
@@ -1059,7 +842,7 @@ cardano_tx_builder_set_network_id(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1097,8 +880,8 @@ cardano_tx_builder_set_change_address(
   }
 
   cardano_address_ref(change_address);
-  cardano_address_unref(&builder->change_address);
-  builder->change_address = change_address;
+  cardano_address_unref(&builder->state.change_address);
+  builder->state.change_address = change_address;
 }
 
 void
@@ -1151,8 +934,8 @@ cardano_tx_builder_set_collateral_change_address(
   }
 
   cardano_address_ref(collateral_change_address);
-  cardano_address_unref(&builder->collateral_address);
-  builder->collateral_address = collateral_change_address;
+  cardano_address_unref(&builder->state.collateral_address);
+  builder->state.collateral_address = collateral_change_address;
 }
 
 void
@@ -1197,7 +980,7 @@ cardano_tx_builder_set_minimum_fee(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1227,7 +1010,7 @@ cardano_tx_builder_set_donation(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1274,8 +1057,8 @@ cardano_tx_builder_set_utxos(
   }
 
   cardano_utxo_list_ref(utxos);
-  cardano_utxo_list_unref(&builder->available_utxos);
-  builder->available_utxos = utxos;
+  cardano_utxo_list_unref(&builder->state.available_utxos);
+  builder->state.available_utxos = utxos;
 }
 
 void
@@ -1296,8 +1079,8 @@ cardano_tx_builder_set_collateral_utxos(
   }
 
   cardano_utxo_list_ref(utxos);
-  cardano_utxo_list_unref(&builder->collateral_utxos);
-  builder->collateral_utxos = utxos;
+  cardano_utxo_list_unref(&builder->state.collateral_utxos);
+  builder->state.collateral_utxos = utxos;
 }
 
 void
@@ -1310,7 +1093,7 @@ cardano_tx_builder_set_invalid_after(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1340,7 +1123,7 @@ cardano_tx_builder_set_invalid_after_ex(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1351,7 +1134,7 @@ cardano_tx_builder_set_invalid_after_ex(
     return;
   }
 
-  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->slot_config);
+  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->state.slot_config);
   cardano_error_t result = cardano_transaction_body_set_invalid_after(body, &slot);
 
   if (result != CARDANO_SUCCESS)
@@ -1371,7 +1154,7 @@ cardano_tx_builder_set_invalid_before(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1401,7 +1184,7 @@ cardano_tx_builder_set_invalid_before_ex(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   if (body == NULL)
@@ -1412,7 +1195,7 @@ cardano_tx_builder_set_invalid_before_ex(
     return;
   }
 
-  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->slot_config);
+  const uint64_t  slot   = unix_time_to_enclosing_slot(unix_time * 1000U, &builder->state.slot_config);
   cardano_error_t result = cardano_transaction_body_set_invalid_before(body, &slot);
 
   if (result != CARDANO_SUCCESS)
@@ -1439,7 +1222,7 @@ cardano_tx_builder_add_reference_input(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_input_set_t* inputs = cardano_transaction_body_get_reference_inputs(body);
@@ -1510,17 +1293,17 @@ cardano_tx_builder_add_reference_input(
     {
       case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
       {
-        builder->has_plutus_v1 = true;
+        builder->state.has_plutus_v1 = true;
         break;
       }
       case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
       {
-        builder->has_plutus_v2 = true;
+        builder->state.has_plutus_v2 = true;
         break;
       }
       case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
       {
-        builder->has_plutus_v3 = true;
+        builder->state.has_plutus_v3 = true;
         break;
       }
       default:
@@ -1530,7 +1313,7 @@ cardano_tx_builder_add_reference_input(
     }
   }
 
-  result = cardano_utxo_list_add(builder->reference_inputs, utxo);
+  result = cardano_utxo_list_add(builder->state.reference_inputs, utxo);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -1567,7 +1350,7 @@ cardano_tx_builder_send_lovelace(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1663,7 +1446,7 @@ cardano_tx_builder_send_value(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1760,7 +1543,7 @@ cardano_tx_builder_lock_lovelace(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1860,7 +1643,7 @@ cardano_tx_builder_lock_value(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1975,7 +1758,7 @@ register_deferred_from_map(
 
   if (result == CARDANO_SUCCESS)
   {
-    result = cardano_deferred_redeemer_list_add(builder->deferred_redeemers, redeemer, callback, user_context);
+    result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
   }
 
   cardano_redeemer_unref(&redeemer);
@@ -2023,7 +1806,7 @@ cardano_tx_builder_add_input(
     return;
   }
 
-  result = cardano_utxo_list_add(builder->pre_selected_inputs, utxo);
+  result = cardano_utxo_list_add(builder->state.pre_selected_inputs, utxo);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2033,7 +1816,7 @@ cardano_tx_builder_add_input(
     return;
   }
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
   cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
@@ -2099,7 +1882,7 @@ cardano_tx_builder_add_input(
     cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
     cardano_transaction_input_unref(&input);
 
-    result = cardano_input_to_redeemer_map_insert(builder->input_to_redeemer_map, input, rdmer);
+    result = cardano_input_to_redeemer_map_insert(builder->state.input_to_redeemer_map, input, rdmer);
 
     if (result != CARDANO_SUCCESS)
     {
@@ -2164,7 +1947,7 @@ cardano_tx_builder_add_output(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -2196,7 +1979,7 @@ cardano_tx_builder_set_metadata(
     return;
   }
 
-  cardano_auxiliary_data_t* auxiliary_data = cardano_transaction_get_auxiliary_data(builder->transaction);
+  cardano_auxiliary_data_t* auxiliary_data = cardano_transaction_get_auxiliary_data(builder->state.transaction);
 
   if (auxiliary_data == NULL)
   {
@@ -2209,7 +1992,7 @@ cardano_tx_builder_set_metadata(
       return;
     }
 
-    result = cardano_transaction_set_auxiliary_data(builder->transaction, auxiliary_data);
+    result = cardano_transaction_set_auxiliary_data(builder->state.transaction, auxiliary_data);
 
     if (result != CARDANO_SUCCESS)
     {
@@ -2258,7 +2041,7 @@ cardano_tx_builder_set_metadata(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_blake2b_hash_t* hash = cardano_auxiliary_data_get_hash(auxiliary_data);
@@ -2335,7 +2118,7 @@ cardano_tx_builder_mint_token(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* tokens = cardano_transaction_body_get_mint(body);
@@ -2379,7 +2162,7 @@ cardano_tx_builder_mint_token(
 
   if (redeemer != NULL)
   {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
     result = add_redeemer(witnesses, policy_id, redeemer, CARDANO_REDEEMER_TAG_MINT, builder);
@@ -2394,7 +2177,7 @@ cardano_tx_builder_mint_token(
   {
     // We still want to add an entry in the mints_to_redeemer_map with a NULL redeemer
     // so it can compute the indices correctly.
-    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->mints_to_redeemer_map, policy_id, NULL);
+    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.mints_to_redeemer_map, policy_id, NULL);
 
     // Avoid error on duplicated key, as it can happen when minting multiple assets
     // under the same policy without redeemer.
@@ -2541,7 +2324,7 @@ cardano_tx_builder_pad_signer_count(
     return;
   }
 
-  builder->additional_signature_count = count;
+  builder->state.additional_signature_count = count;
 }
 
 void
@@ -2562,7 +2345,7 @@ cardano_tx_builder_add_signer(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_guard_set_t* guards = cardano_transaction_body_get_guards(body);
@@ -2668,7 +2451,7 @@ cardano_tx_builder_add_datum(
     return;
   }
 
-  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witness_set);
 
   cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witness_set);
@@ -2737,7 +2520,7 @@ cardano_tx_builder_withdraw_rewards(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_withdrawal_map_t* withdrawals = cardano_transaction_body_get_withdrawals(body);
@@ -2791,7 +2574,7 @@ cardano_tx_builder_withdraw_rewards(
 
   if (redeemer != NULL)
   {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
     result = add_redeemer(witnesses, hash, redeemer, CARDANO_REDEEMER_TAG_REWARD, builder);
@@ -2825,7 +2608,7 @@ cardano_tx_builder_withdraw_rewards(
     // the redeemer index.
     if (cred_type != CARDANO_CREDENTIAL_TYPE_KEY_HASH)
     {
-      result = cardano_blake2b_hash_to_redeemer_map_insert(builder->withdrawals_to_redeemer_map, hash, NULL);
+      result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.withdrawals_to_redeemer_map, hash, NULL);
 
       if (result != CARDANO_SUCCESS)
       {
@@ -2895,7 +2678,7 @@ cardano_tx_builder_register_reward_address(
   cardano_credential_t* credential = cardano_reward_address_get_credential(address);
   cardano_credential_unref(&credential);
 
-  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->params);
+  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->state.params);
 
   cardano_certificate_t*       cert         = NULL;
   cardano_registration_cert_t* registration = NULL;
@@ -2977,7 +2760,7 @@ cardano_tx_builder_deregister_reward_address(
   cardano_credential_t* credential = cardano_reward_address_get_credential(address);
   cardano_credential_unref(&credential);
 
-  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->params);
+  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->state.params);
 
   cardano_certificate_t*         cert           = NULL;
   cardano_unregistration_cert_t* unregistration = NULL;
@@ -3317,7 +3100,7 @@ cardano_tx_builder_register_drep(
     return;
   }
 
-  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->params);
+  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->state.params);
   result                 = cardano_register_drep_cert_new(credential, deposit, anchor, &register_drep);
 
   if (result != CARDANO_SUCCESS)
@@ -3532,7 +3315,7 @@ cardano_tx_builder_deregister_drep(
     return;
   }
 
-  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->params);
+  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->state.params);
   result                 = cardano_unregister_drep_cert_new(credential, deposit, &deregistration);
 
   if (result != CARDANO_SUCCESS)
@@ -3623,7 +3406,7 @@ cardano_tx_builder_vote(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_voting_procedures_t* votes = cardano_transaction_body_get_voting_procedures(body);
@@ -3673,7 +3456,7 @@ cardano_tx_builder_vote(
 
   if (redeemer != NULL)
   {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
     result = add_redeemer(witnesses, id_hash, redeemer, CARDANO_REDEEMER_TAG_VOTING, builder);
@@ -3687,7 +3470,7 @@ cardano_tx_builder_vote(
   }
   else
   {
-    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->votes_to_redeemer_map, id_hash, NULL);
+    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.votes_to_redeemer_map, id_hash, NULL);
 
     if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
     {
@@ -3720,7 +3503,7 @@ cardano_tx_builder_add_certificate(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -3796,7 +3579,7 @@ cardano_tx_builder_add_certificate(
       return;
     }
 
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
     cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
@@ -3873,17 +3656,17 @@ cardano_tx_builder_add_script(
   {
     case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
     {
-      builder->has_plutus_v1 = true;
+      builder->state.has_plutus_v1 = true;
       break;
     }
     case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
     {
-      builder->has_plutus_v2 = true;
+      builder->state.has_plutus_v2 = true;
       break;
     }
     case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
     {
-      builder->has_plutus_v3 = true;
+      builder->state.has_plutus_v3 = true;
       break;
     }
     default:
@@ -3892,7 +3675,7 @@ cardano_tx_builder_add_script(
     }
   }
 
-  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witness_set = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witness_set);
 
   result = cardano_witness_set_add_script(witness_set, script);
@@ -3936,7 +3719,7 @@ cardano_tx_builder_propose_parameter_change(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_parameter_change_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -3949,7 +3732,7 @@ cardano_tx_builder_propose_parameter_change(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -3964,7 +3747,7 @@ cardano_tx_builder_propose_parameter_change(
 
   cardano_proposal_procedure_unref(&proposal);
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
   const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
 
@@ -4117,7 +3900,7 @@ cardano_tx_builder_propose_hardfork(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_hard_fork_initiation_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -4130,7 +3913,7 @@ cardano_tx_builder_propose_hardfork(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4279,7 +4062,7 @@ cardano_tx_builder_propose_treasury_withdrawals(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_treasury_withdrawals_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -4292,7 +4075,7 @@ cardano_tx_builder_propose_treasury_withdrawals(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4306,7 +4089,7 @@ cardano_tx_builder_propose_treasury_withdrawals(
     builder->last_error = result;
   }
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
   const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
 
@@ -4429,7 +4212,7 @@ cardano_tx_builder_propose_no_confidence(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_no_confidence_action(deposit, reward_address, anchor, action, &proposal);
   cardano_no_confidence_action_unref(&action);
@@ -4441,7 +4224,7 @@ cardano_tx_builder_propose_no_confidence(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4570,7 +4353,7 @@ cardano_tx_builder_propose_update_committee(
 
   cardano_proposal_procedure_t* proposal;
 
-  const uint64_t deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_update_committee_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -4583,7 +4366,7 @@ cardano_tx_builder_propose_update_committee(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4728,7 +4511,7 @@ cardano_tx_builder_propose_new_constitution(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_constitution_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -4741,7 +4524,7 @@ cardano_tx_builder_propose_new_constitution(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4867,7 +4650,7 @@ cardano_tx_builder_propose_info(
   }
 
   cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->params);
+  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
 
   result = cardano_proposal_procedure_new_info_action(deposit, reward_address, anchor, action, &proposal);
 
@@ -4880,7 +4663,7 @@ cardano_tx_builder_propose_info(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
@@ -4981,7 +4764,7 @@ cardano_tx_builder_build(
     return builder->last_error;
   }
 
-  if (builder->change_address == NULL)
+  if (builder->state.change_address == NULL)
   {
     builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
     cardano_tx_builder_set_last_error(
@@ -4991,7 +4774,7 @@ cardano_tx_builder_build(
     return builder->last_error;
   }
 
-  if (builder->available_utxos == NULL)
+  if (builder->state.available_utxos == NULL)
   {
     builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
     cardano_tx_builder_set_last_error(
@@ -5001,9 +4784,9 @@ cardano_tx_builder_build(
     return builder->last_error;
   }
 
-  if (cardano_transaction_has_script_data(builder->transaction))
+  if (cardano_transaction_has_script_data(builder->state.transaction))
   {
-    if (builder->collateral_address == NULL)
+    if (builder->state.collateral_address == NULL)
     {
       builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
       cardano_tx_builder_set_last_error(
@@ -5013,7 +4796,7 @@ cardano_tx_builder_build(
       return builder->last_error;
     }
 
-    if (builder->collateral_utxos == NULL)
+    if (builder->state.collateral_utxos == NULL)
     {
       builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
       cardano_tx_builder_set_last_error(
@@ -5024,7 +4807,7 @@ cardano_tx_builder_build(
     }
   }
 
-  cardano_transaction_t* tx = builder->transaction;
+  cardano_transaction_t* tx = builder->state.transaction;
 
   cardano_error_t result = set_dummy_script_data_hash(tx);
 
@@ -5036,18 +4819,18 @@ cardano_tx_builder_build(
 
   result = cardano_balance_transaction(
     tx,
-    builder->additional_signature_count,
-    builder->params,
-    builder->reference_inputs,
-    builder->pre_selected_inputs,
-    builder->input_to_redeemer_map,
-    builder->available_utxos,
-    builder->coin_selector,
-    builder->change_address,
-    builder->collateral_utxos,
-    builder->collateral_address,
-    builder->tx_evaluator,
-    builder->deferred_redeemers);
+    builder->state.additional_signature_count,
+    builder->state.params,
+    builder->state.reference_inputs,
+    builder->state.pre_selected_inputs,
+    builder->state.input_to_redeemer_map,
+    builder->state.available_utxos,
+    builder->state.coin_selector,
+    builder->state.change_address,
+    builder->state.collateral_utxos,
+    builder->state.collateral_address,
+    builder->state.tx_evaluator,
+    builder->state.deferred_redeemers);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -5175,11 +4958,11 @@ cardano_tx_builder_add_input_with_deferred_redeemer(
 
   cardano_redeemer_t* redeemer = NULL;
 
-  result = cardano_input_to_redeemer_map_get(builder->input_to_redeemer_map, input, &redeemer);
+  result = cardano_input_to_redeemer_map_get(builder->state.input_to_redeemer_map, input, &redeemer);
 
   if (result == CARDANO_SUCCESS)
   {
-    result = cardano_deferred_redeemer_list_add(builder->deferred_redeemers, redeemer, callback, user_context);
+    result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
   }
 
   cardano_redeemer_unref(&redeemer);
@@ -5234,7 +5017,7 @@ cardano_tx_builder_mint_token_with_deferred_redeemer(
     return;
   }
 
-  register_deferred_from_map(builder, builder->mints_to_redeemer_map, policy_id, callback, user_context);
+  register_deferred_from_map(builder, builder->state.mints_to_redeemer_map, policy_id, callback, user_context);
 }
 
 void
@@ -5294,7 +5077,7 @@ cardano_tx_builder_withdraw_rewards_with_deferred_redeemer(
     return;
   }
 
-  register_deferred_from_map(builder, builder->withdrawals_to_redeemer_map, hash, callback, user_context);
+  register_deferred_from_map(builder, builder->state.withdrawals_to_redeemer_map, hash, callback, user_context);
 
   cardano_blake2b_hash_unref(&hash);
 }
@@ -5340,7 +5123,7 @@ cardano_tx_builder_add_certificate_with_deferred_redeemer(
     return;
   }
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5348,7 +5131,7 @@ cardano_tx_builder_add_certificate_with_deferred_redeemer(
 
   const uint64_t cert_index = (uint64_t)(cardano_certificate_set_get_length(certs) - 1U);
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
   cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
@@ -5375,7 +5158,7 @@ cardano_tx_builder_add_certificate_with_deferred_redeemer(
 
     if (matches)
     {
-      result = cardano_deferred_redeemer_list_add(builder->deferred_redeemers, redeemer, callback, user_context);
+      result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
     }
 
     cardano_redeemer_unref(&redeemer);
@@ -5443,7 +5226,7 @@ cardano_tx_builder_vote_with_deferred_redeemer(
     return;
   }
 
-  register_deferred_from_map(builder, builder->votes_to_redeemer_map, hash, callback, user_context);
+  register_deferred_from_map(builder, builder->state.votes_to_redeemer_map, hash, callback, user_context);
 
   cardano_blake2b_hash_unref(&hash);
 }

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -32,21 +32,15 @@
 
 #include "../allocators.h"
 #include "./internals/blake2b_hash_to_redeemer_map.h"
+#include "./internals/builder_certs.h"
 #include "./internals/builder_inputs.h"
 #include "./internals/builder_mint.h"
 #include "./internals/builder_outputs.h"
 #include "./internals/builder_redeemers.h"
 #include "./internals/builder_state.h"
+#include "./internals/builder_withdrawals.h"
 
 #include <assert.h>
-#include <cardano/certs/register_drep_cert.h>
-#include <cardano/certs/registration_cert.h>
-#include <cardano/certs/stake_delegation_cert.h>
-#include <cardano/certs/unregister_drep_cert.h>
-#include <cardano/certs/unregistration_cert.h>
-#include <cardano/certs/update_drep_cert.h>
-#include <cardano/certs/vote_delegation_cert.h>
-#include <cardano/encoding/bech32.h>
 #include <cardano/proposal_procedures/constitution.h>
 #include <cardano/proposal_procedures/hard_fork_initiation_action.h>
 #include <cardano/proposal_procedures/info_action.h>
@@ -55,7 +49,6 @@
 #include <cardano/proposal_procedures/parameter_change_action.h>
 #include <cardano/proposal_procedures/treasury_withdrawals_action.h>
 #include <src/string_safe.h>
-#include <string.h>
 
 /* STRUCTURES ****************************************************************/
 
@@ -564,67 +557,6 @@ compute_voting_procedures_sortable_id(cardano_voter_t* voter, cardano_blake2b_ha
   *id = id_hash;
 
   return CARDANO_SUCCESS;
-}
-
-/**
- * @brief Computes a deterministic, sortable hash ID for a credential.
- *
- * This function creates a unique identifier by concatenating the credential's type
- * and its raw hash bytes.
- *
- * @param[in] credential A pointer to the `cardano_credential_t` object.
- * @param[out] id On success, this will be populated with a pointer to a newly allocated
- * `cardano_blake2b_hash_t` object representing the unique ID.
- *
- * @return `CARDANO_SUCCESS` if the ID was computed successfully, or an appropriate
- * error code on failure.
- *
- * @note The caller is responsible for managing the lifecycle of the returned `id` object
- * and must release it by calling `cardano_blake2b_hash_unref`.
- */
-static cardano_error_t
-compute_credential_sortable_id(cardano_credential_t* credential, cardano_blake2b_hash_t** id)
-{
-  if ((credential == NULL) || (id == NULL))
-  {
-    return CARDANO_ERROR_INVALID_ARGUMENT;
-  }
-
-  cardano_credential_type_t type;
-  cardano_error_t           result = cardano_credential_get_type(credential, &type);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  cardano_blake2b_hash_t* hash       = cardano_credential_get_hash(credential);
-  const byte_t*           hash_bytes = cardano_blake2b_hash_get_data(hash);
-  size_t                  hash_size  = cardano_blake2b_hash_get_bytes_size(hash);
-
-  const size_t total_size = sizeof(type) + hash_size;
-  byte_t*      id_bytes   = (byte_t*)_cardano_malloc(total_size);
-
-  if (id_bytes == NULL)
-  {
-    cardano_blake2b_hash_unref(&hash);
-    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
-  }
-
-  size_t cursor = 0;
-
-  cardano_safe_memcpy(&id_bytes[cursor], total_size, &type, sizeof(type));
-  cursor += sizeof(type);
-
-  cardano_safe_memcpy(&id_bytes[cursor], total_size - cursor, hash_bytes, hash_size);
-
-  cardano_blake2b_hash_unref(&hash);
-
-  result = cardano_blake2b_hash_from_bytes(id_bytes, total_size, id);
-
-  _cardano_free(id_bytes);
-
-  return result;
 }
 
 /* DEFINITIONS ****************************************************************/
@@ -1684,123 +1616,11 @@ cardano_tx_builder_withdraw_rewards(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (amount < 0)
-  {
-    cardano_tx_builder_set_last_error(builder, "Amount must be greater than zero.");
-    builder->last_error = CARDANO_ERROR_INVALID_ARGUMENT;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_withdraw_rewards(&builder->state, address, amount, redeemer, &error_message);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_withdrawal_map_t* withdrawals = cardano_transaction_body_get_withdrawals(body);
-
-  if (withdrawals == NULL)
-  {
-    cardano_error_t result = cardano_withdrawal_map_new(&withdrawals);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create withdrawal map.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_transaction_body_set_withdrawals(body, withdrawals);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set withdrawal map.");
-      cardano_withdrawal_map_unref(&withdrawals);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_withdrawal_map_unref(&withdrawals);
-
-  cardano_error_t result = cardano_withdrawal_map_insert(withdrawals, address, amount);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to insert withdrawal.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
-
-  cardano_blake2b_hash_t* hash = NULL;
-
-  result = compute_credential_sortable_id(credential, &hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to compute credential sortable ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  if (redeemer != NULL)
-  {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-    cardano_witness_set_unref(&witnesses);
-
-    const char* error_message = NULL;
-
-    result = cardano_builder_add_redeemer(witnesses, hash, redeemer, CARDANO_REDEEMER_TAG_REWARD, &builder->state, &error_message);
-
-    cardano_blake2b_hash_unref(&hash);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add redeemer.");
-      builder->last_error = result;
-    }
-  }
-  else
-  {
-    // We still want to add an entry in the withdrawals_to_redeemer_map with a NULL redeemer
-    // so it can compute the indices correctly.
-    cardano_credential_type_t cred_type = CARDANO_CREDENTIAL_TYPE_KEY_HASH;
-    result                              = cardano_credential_get_type(credential, &cred_type);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_blake2b_hash_unref(&hash);
-      cardano_tx_builder_set_last_error(builder, "Failed to add withdrawal.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    // For withdrawals due to a quirk in the node, script credentials are processed first than pub key
-    // hash credentials regardless of the canonical sorting, so we need to skip them when computing
-    // the redeemer index.
-    if (cred_type != CARDANO_CREDENTIAL_TYPE_KEY_HASH)
-    {
-      result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.withdrawals_to_redeemer_map, hash, NULL);
-
-      if (result != CARDANO_SUCCESS)
-      {
-        cardano_blake2b_hash_unref(&hash);
-        cardano_tx_builder_set_last_error(builder, "Failed to add withdrawal.");
-        builder->last_error = result;
-        return;
-      }
-    }
-
-    cardano_blake2b_hash_unref(&hash);
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1816,25 +1636,11 @@ cardano_tx_builder_withdraw_rewards_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_reward_address_t* addr   = NULL;
-  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+  const cardano_error_t result = cardano_builder_withdraw_rewards_ex(&builder->state, reward_address, address_size, amount, redeemer, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_withdraw_rewards(builder, addr, amount, redeemer);
-  cardano_reward_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1848,42 +1654,11 @@ cardano_tx_builder_register_reward_address(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
+  const cardano_error_t result = cardano_builder_register_reward_address(&builder->state, address, redeemer, &error_message);
 
-  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->state.params);
-
-  cardano_certificate_t*       cert         = NULL;
-  cardano_registration_cert_t* registration = NULL;
-  cardano_error_t              result       = cardano_registration_cert_new(credential, deposit, &registration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create registration certificate.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  result = cardano_certificate_new_registration(registration, &cert);
-  cardano_registration_cert_unref(&registration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1898,25 +1673,11 @@ cardano_tx_builder_register_reward_address_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_reward_address_t* addr   = NULL;
-  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
+  const cardano_error_t result = cardano_builder_register_reward_address_ex(&builder->state, reward_address, address_size, redeemer, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_register_reward_address(builder, addr, redeemer);
-  cardano_reward_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1930,43 +1691,11 @@ cardano_tx_builder_deregister_reward_address(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
+  const cardano_error_t result = cardano_builder_deregister_reward_address(&builder->state, address, redeemer, &error_message);
 
-  const uint64_t deposit = cardano_protocol_parameters_get_key_deposit(builder->state.params);
-
-  cardano_certificate_t*         cert           = NULL;
-  cardano_unregistration_cert_t* unregistration = NULL;
-
-  cardano_error_t result = cardano_unregistration_cert_new(credential, deposit, &unregistration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create unregistration certificate.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  result = cardano_certificate_new_unregistration(unregistration, &cert);
-  cardano_unregistration_cert_unref(&unregistration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1981,26 +1710,11 @@ cardano_tx_builder_deregister_reward_address_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_reward_address_t* addr = NULL;
+  const cardano_error_t result = cardano_builder_deregister_reward_address_ex(&builder->state, reward_address, address_size, redeemer, &error_message);
 
-  cardano_error_t result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_deregister_reward_address(builder, addr, redeemer);
-  cardano_reward_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2015,47 +1729,11 @@ cardano_tx_builder_delegate_stake(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (pool_id == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Pool ID is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_delegate_stake(&builder->state, address, pool_id, redeemer, &error_message);
 
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
-
-  cardano_certificate_t*           cert       = NULL;
-  cardano_stake_delegation_cert_t* delegation = NULL;
-
-  cardano_error_t result = cardano_stake_delegation_cert_new(credential, pool_id, &delegation);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create delegation certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_certificate_new_stake_delegation(delegation, &cert);
-  cardano_stake_delegation_cert_unref(&delegation);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2072,69 +1750,11 @@ cardano_tx_builder_delegate_stake_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_delegate_stake_ex(&builder->state, reward_address, address_size, pool_id, pool_id_size, redeemer, &error_message);
 
-  if ((pool_id == NULL) || (pool_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Pool ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-
-    return;
-  }
-
-  byte_t pool_id_hex[28] = { 0 };
-  char   pool_hrp[5]     = { 0 };
-
-  cardano_error_t result = cardano_encoding_bech32_decode(pool_id, pool_id_size, pool_hrp, sizeof(pool_hrp), pool_id_hex, sizeof(pool_id_hex));
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to decode pool ID.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  if (strncmp(pool_hrp, "pool", 4) != 0)
-  {
-    cardano_tx_builder_set_last_error(builder, "Invalid pool ID.");
-    builder->last_error = CARDANO_ERROR_INVALID_ARGUMENT;
-
-    return;
-  }
-
-  cardano_blake2b_hash_t* hash = NULL;
-  result                       = cardano_blake2b_hash_from_bytes(pool_id_hex, sizeof(pool_id_hex), &hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse pool ID.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_blake2b_hash_unref(&hash);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_delegate_stake(builder, addr, hash, redeemer);
-  cardano_reward_address_unref(&addr);
-  cardano_blake2b_hash_unref(&hash);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2149,47 +1769,11 @@ cardano_tx_builder_delegate_voting_power(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (drep == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "DREP is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_delegate_voting_power(&builder->state, address, drep, redeemer, &error_message);
 
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
-
-  cardano_certificate_t*          cert       = NULL;
-  cardano_vote_delegation_cert_t* delegation = NULL;
-
-  cardano_error_t result = cardano_vote_delegation_cert_new(credential, drep, &delegation);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create delegation certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_certificate_new_vote_delegation(delegation, &cert);
-  cardano_vote_delegation_cert_unref(&delegation);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2206,45 +1790,11 @@ cardano_tx_builder_delegate_voting_power_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((drep_id == NULL) || (drep_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "DREP ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_delegate_voting_power_ex(&builder->state, reward_address, address_size, drep_id, drep_id_size, redeemer, &error_message);
 
-  cardano_reward_address_t* addr   = NULL;
-  cardano_error_t           result = cardano_reward_address_from_bech32(reward_address, address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_drep_t* drep = NULL;
-  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse DREP ID.");
-    cardano_reward_address_unref(&addr);
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_delegate_voting_power(builder, addr, drep, redeemer);
-
-  cardano_reward_address_unref(&addr);
-  cardano_drep_unref(&drep);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2259,50 +1809,11 @@ cardano_tx_builder_register_drep(
     return;
   }
 
-  if (drep == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_certificate_t*        cert          = NULL;
-  cardano_register_drep_cert_t* register_drep = NULL;
-  cardano_credential_t*         credential    = NULL;
+  const cardano_error_t result = cardano_builder_register_drep(&builder->state, drep, anchor, redeemer, &error_message);
 
-  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
-  cardano_credential_unref(&credential);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to get credential.");
-    builder->last_error = result;
-    return;
-  }
-
-  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->state.params);
-  result                 = cardano_register_drep_cert_new(credential, deposit, anchor, &register_drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create DRep registration certificate.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  result = cardano_certificate_new_register_drep(register_drep, &cert);
-  cardano_register_drep_cert_unref(&register_drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2321,39 +1832,11 @@ cardano_tx_builder_register_drep_ex(
     return;
   }
 
-  if ((drep_id == NULL) || (drep_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_anchor_t* anchor = NULL;
+  const cardano_error_t result = cardano_builder_register_drep_ex(&builder->state, drep_id, drep_id_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, redeemer, &error_message);
 
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_drep_t* drep = NULL;
-  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse DRep ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_register_drep(builder, drep, anchor, redeemer);
-
-  cardano_drep_unref(&drep);
-  cardano_anchor_unref(&anchor);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2368,48 +1851,11 @@ cardano_tx_builder_update_drep(
     return;
   }
 
-  if (drep == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_certificate_t*      cert        = NULL;
-  cardano_update_drep_cert_t* update_drep = NULL;
-  cardano_credential_t*       credential  = NULL;
+  const cardano_error_t result = cardano_builder_update_drep(&builder->state, drep, anchor, redeemer, &error_message);
 
-  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
-  cardano_credential_unref(&credential);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to get credential.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_update_drep_cert_new(credential, anchor, &update_drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create DRep update certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_certificate_new_update_drep(update_drep, &cert);
-  cardano_update_drep_cert_unref(&update_drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2428,39 +1874,11 @@ cardano_tx_builder_update_drep_ex(
     return;
   }
 
-  if ((drep_id == NULL) || (drep_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_anchor_t* anchor = NULL;
+  const cardano_error_t result = cardano_builder_update_drep_ex(&builder->state, drep_id, drep_id_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, redeemer, &error_message);
 
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_drep_t* drep = NULL;
-  result               = cardano_drep_from_string(drep_id, drep_id_size, &drep);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse DRep ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_update_drep(builder, drep, anchor, redeemer);
-
-  cardano_drep_unref(&drep);
-  cardano_anchor_unref(&anchor);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2474,49 +1892,11 @@ cardano_tx_builder_deregister_drep(
     return;
   }
 
-  if (drep == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_certificate_t*          cert           = NULL;
-  cardano_unregister_drep_cert_t* deregistration = NULL;
-  cardano_credential_t*           credential     = NULL;
+  const cardano_error_t result = cardano_builder_deregister_drep(&builder->state, drep, redeemer, &error_message);
 
-  cardano_error_t result = cardano_drep_get_credential(drep, &credential);
-  cardano_credential_unref(&credential);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to get credential.");
-    builder->last_error = result;
-    return;
-  }
-
-  const uint64_t deposit = cardano_protocol_parameters_get_drep_deposit(builder->state.params);
-  result                 = cardano_unregister_drep_cert_new(credential, deposit, &deregistration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create DRep deregistration certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_certificate_new_unregister_drep(deregistration, &cert);
-  cardano_unregister_drep_cert_unref(&deregistration);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, cert, redeemer);
-  cardano_certificate_unref(&cert);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2531,25 +1911,11 @@ cardano_tx_builder_deregister_drep_ex(
     return;
   }
 
-  if ((drep_id == NULL) || (drep_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "DRep ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_drep_t* drep   = NULL;
-  cardano_error_t result = cardano_drep_from_string(drep_id, drep_id_size, &drep);
+  const cardano_error_t result = cardano_builder_deregister_drep_ex(&builder->state, drep_id, drep_id_size, redeemer, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse DRep ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_deregister_drep(builder, drep, redeemer);
-  cardano_drep_unref(&drep);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2678,131 +2044,11 @@ cardano_tx_builder_add_certificate(
     return;
   }
 
-  if (certificate == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Certificate is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const cardano_error_t result = cardano_builder_add_certificate(&builder->state, certificate, redeemer, &error_message);
 
-  cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
-
-  if (certs == NULL)
-  {
-    cardano_error_t result = cardano_certificate_set_new(&certs);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create certificate set.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_transaction_body_set_certificates(body, certs);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set certificate set.");
-      cardano_certificate_set_unref(&certs);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_certificate_set_unref(&certs);
-
-  cardano_error_t result = cardano_certificate_set_add(certs, certificate);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add certificate.");
-    builder->last_error = result;
-    return;
-  }
-
-  if (redeemer != NULL)
-  {
-    cardano_redeemer_t* rdmer = NULL;
-
-    cardano_ex_units_t* ex_units = NULL;
-    result                       = cardano_ex_units_new(0, 0, &ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create execution units.");
-      builder->last_error = result;
-      return;
-    }
-
-    const size_t certs_size = cardano_certificate_set_get_length(certs);
-
-    if (certs_size == 0U)
-    {
-      cardano_redeemer_unref(&rdmer);
-      cardano_tx_builder_set_last_error(builder, "Unexpected empty certificate set.");
-      builder->last_error = CARDANO_ERROR_INVALID_ARGUMENT;
-
-      return;
-    }
-
-    const size_t cert_index = cardano_certificate_set_get_length(certs) - 1U;
-
-    result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_CERTIFYING, cert_index, redeemer, ex_units, &rdmer);
-    cardano_ex_units_unref(&ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create redeemer.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-    cardano_witness_set_unref(&witnesses);
-
-    cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
-
-    if (redeemers == NULL)
-    {
-      result = cardano_redeemer_list_new(&redeemers);
-
-      if (result != CARDANO_SUCCESS)
-      {
-        cardano_redeemer_unref(&rdmer);
-        cardano_tx_builder_set_last_error(builder, "Failed to create redeemer list.");
-        builder->last_error = result;
-
-        return;
-      }
-
-      result = cardano_witness_set_set_redeemers(witnesses, redeemers);
-
-      if (result != CARDANO_SUCCESS)
-      {
-        cardano_redeemer_unref(&rdmer);
-        cardano_tx_builder_set_last_error(builder, "Failed to set redeemer list.");
-        cardano_redeemer_list_unref(&redeemers);
-        builder->last_error = result;
-
-        return;
-      }
-    }
-
-    cardano_redeemer_list_unref(&redeemers);
-
-    result = cardano_redeemer_list_add(redeemers, rdmer);
-    cardano_redeemer_unref(&rdmer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add redeemer.");
-      builder->last_error = result;
-    }
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -4147,57 +3393,11 @@ cardano_tx_builder_withdraw_rewards_with_deferred_redeemer(
     return;
   }
 
-  if ((address == NULL) || (callback == NULL))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address and callback are required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-
-    return;
-  }
-
-  cardano_plutus_data_t* placeholder = NULL;
-
-  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create the placeholder redeemer.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_withdraw_rewards(builder, address, amount, placeholder);
-
-  cardano_plutus_data_unref(&placeholder);
-
-  if (builder->last_error != CARDANO_SUCCESS)
-  {
-    return;
-  }
-
-  cardano_credential_t* credential = cardano_reward_address_get_credential(address);
-  cardano_credential_unref(&credential);
-
-  cardano_blake2b_hash_t* hash = NULL;
-
-  result = compute_credential_sortable_id(credential, &hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to compute the withdrawal sortable id.");
-    builder->last_error = result;
-
-    return;
-  }
-
   const char* error_message = NULL;
 
-  result = cardano_builder_register_deferred_from_map(&builder->state, builder->state.withdrawals_to_redeemer_map, hash, callback, user_context, &error_message);
+  const cardano_error_t result = cardano_builder_withdraw_rewards_with_deferred_redeemer(&builder->state, address, amount, callback, user_context, &error_message);
 
   track_builder_result(builder, result, error_message);
-
-  cardano_blake2b_hash_unref(&hash);
 }
 
 void
@@ -4212,81 +3412,11 @@ cardano_tx_builder_add_certificate_with_deferred_redeemer(
     return;
   }
 
-  if ((certificate == NULL) || (callback == NULL))
-  {
-    cardano_tx_builder_set_last_error(builder, "Certificate and callback are required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_certificate_with_deferred_redeemer(&builder->state, certificate, callback, user_context, &error_message);
 
-  cardano_plutus_data_t* placeholder = NULL;
-
-  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create the placeholder redeemer.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_add_certificate(builder, certificate, placeholder);
-
-  cardano_plutus_data_unref(&placeholder);
-
-  if (builder->last_error != CARDANO_SUCCESS)
-  {
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
-  cardano_certificate_set_unref(&certs);
-
-  const uint64_t cert_index = (uint64_t)(cardano_certificate_set_get_length(certs) - 1U);
-
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witnesses);
-
-  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
-  cardano_redeemer_list_unref(&redeemers);
-
-  result = CARDANO_ERROR_ELEMENT_NOT_FOUND;
-
-  const size_t redeemer_count = cardano_redeemer_list_get_length(redeemers);
-
-  for (size_t i = 0U; (i < redeemer_count) && (result == CARDANO_ERROR_ELEMENT_NOT_FOUND); ++i)
-  {
-    cardano_redeemer_t* redeemer = NULL;
-
-    const cardano_error_t get_result = cardano_redeemer_list_get(redeemers, i, &redeemer);
-
-    if (get_result != CARDANO_SUCCESS)
-    {
-      result = get_result;
-      break;
-    }
-
-    const bool matches = (cardano_redeemer_get_tag(redeemer) == CARDANO_REDEEMER_TAG_CERTIFYING) &&
-      (cardano_redeemer_get_index(redeemer) == cert_index);
-
-    if (matches)
-    {
-      result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
-    }
-
-    cardano_redeemer_unref(&redeemer);
-  }
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to register the deferred redeemer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -21,8 +21,6 @@
 
 /* INCLUDES ******************************************************************/
 
-#include <cardano/plutus_data/constr_plutus_data.h>
-#include <cardano/plutus_data/plutus_list.h>
 #include <cardano/transaction_builder/transaction_builder.h>
 
 #include <cardano/object.h>
@@ -34,6 +32,10 @@
 
 #include "../allocators.h"
 #include "./internals/blake2b_hash_to_redeemer_map.h"
+#include "./internals/builder_inputs.h"
+#include "./internals/builder_mint.h"
+#include "./internals/builder_outputs.h"
+#include "./internals/builder_redeemers.h"
 #include "./internals/builder_state.h"
 
 #include <assert.h>
@@ -100,6 +102,36 @@ cardano_tx_builder_deallocate(void* object)
   cardano_builder_state_release(&builder->state);
 
   _cardano_free(builder);
+}
+
+/**
+ * \brief Records the outcome of an internal builder operation in the builder.
+ *
+ * This function stores the error code of a failed internal operation as the builder deferred error
+ * and, when the operation reported an error message, copies it into the builder last error message.
+ * A successful outcome leaves the builder untouched.
+ *
+ * \param[in,out] builder A pointer to the \ref cardano_tx_builder_t that receives the outcome. This
+ *                        parameter must not be NULL.
+ * \param[in] result The error code returned by the internal operation.
+ * \param[in] error_message The error message reported by the internal operation, or NULL when the
+ *                          operation did not report one.
+ */
+static void
+track_builder_result(
+  cardano_tx_builder_t* builder,
+  const cardano_error_t result,
+  const char*           error_message)
+{
+  if (result != CARDANO_SUCCESS)
+  {
+    if (error_message != NULL)
+    {
+      cardano_tx_builder_set_last_error(builder, error_message);
+    }
+
+    builder->last_error = result;
+  }
 }
 
 /**
@@ -307,163 +339,6 @@ update_script_data_hash(cardano_tx_builder_t* builder, cardano_transaction_t* tx
 
   result = cardano_transaction_body_set_script_data_hash(body, hash);
   cardano_blake2b_hash_unref(&hash);
-
-  return result;
-}
-
-/**
- * \brief Adds a redeemer to the witness set.
- *
- * This function creates and adds a new redeemer to the given witness set. The redeemer is initialized with
- * the provided data, tag.
- *
- * \param[in,out] witness_set A pointer to the \ref cardano_witness_set_t object where the redeemer will be added.
- * \param[in]     data        A pointer to the \ref cardano_plutus_data_t object containing the execution data for the redeemer.
- * \param[in]     tag         The tag indicating the context in which the redeemer is used (e.g., spending, minting, etc.).
- *
- * \return \ref CARDANO_SUCCESS if the redeemer was successfully added, or an appropriate error code indicating the failure reason.
- */
-static cardano_error_t
-add_redeemer(
-  cardano_witness_set_t*       witness_set,
-  cardano_blake2b_hash_t*      hash,
-  cardano_plutus_data_t*       data,
-  const cardano_redeemer_tag_t tag,
-  cardano_tx_builder_t*        builder)
-{
-  cardano_error_t          result    = CARDANO_SUCCESS;
-  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witness_set);
-
-  if (redeemers == NULL)
-  {
-    result = cardano_redeemer_list_new(&redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_witness_set_set_redeemers(witness_set, redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_redeemer_list_unref(&redeemers);
-      return result;
-    }
-  }
-
-  cardano_redeemer_list_unref(&redeemers);
-
-  if (data != NULL)
-  {
-    cardano_redeemer_t* rdmer = NULL;
-
-    cardano_ex_units_t* ex_units = NULL;
-    result                       = cardano_ex_units_new(0, 0, &ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_redeemer_new(tag, 0, data, ex_units, &rdmer);
-    cardano_ex_units_unref(&ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    bool duplicate = false;
-
-    switch (tag)
-    {
-      case CARDANO_REDEEMER_TAG_MINT:
-      {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.mints_to_redeemer_map, hash, rdmer);
-
-        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-        {
-          cardano_tx_builder_set_last_error(builder, "Failed to insert plutus data to redeemer map.");
-          builder->last_error = result;
-
-          cardano_redeemer_unref(&rdmer);
-
-          return result;
-        }
-
-        if (result == CARDANO_ERROR_DUPLICATED_KEY)
-        {
-          duplicate = true;
-          result    = CARDANO_SUCCESS;
-        }
-
-        break;
-      }
-      case CARDANO_REDEEMER_TAG_REWARD:
-      {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.withdrawals_to_redeemer_map, hash, rdmer);
-
-        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-        {
-          cardano_tx_builder_set_last_error(builder, "Failed to insert plutus data to redeemer map.");
-          builder->last_error = result;
-
-          cardano_redeemer_unref(&rdmer);
-
-          return result;
-        }
-
-        if (result == CARDANO_ERROR_DUPLICATED_KEY)
-        {
-          duplicate = true;
-          result    = CARDANO_SUCCESS;
-        }
-
-        break;
-      }
-      case CARDANO_REDEEMER_TAG_VOTING:
-      {
-        result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.votes_to_redeemer_map, hash, rdmer);
-
-        if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-        {
-          cardano_tx_builder_set_last_error(builder, "Failed to insert plutus data to redeemer map.");
-          builder->last_error = result;
-
-          cardano_redeemer_unref(&rdmer);
-
-          return result;
-        }
-
-        if (result == CARDANO_ERROR_DUPLICATED_KEY)
-        {
-          duplicate = true;
-          result    = CARDANO_SUCCESS;
-        }
-
-        break;
-      }
-      case CARDANO_REDEEMER_TAG_CERTIFYING:
-      case CARDANO_REDEEMER_TAG_PROPOSING:
-      case CARDANO_REDEEMER_TAG_SPEND:
-      case CARDANO_REDEEMER_TAG_GUARDING:
-      default:
-      {
-        cardano_tx_builder_set_last_error(builder, "Invalid redeemer tag.");
-        cardano_redeemer_unref(&rdmer);
-
-        return CARDANO_ERROR_ILLEGAL_STATE;
-      }
-    }
-
-    if (!duplicate)
-    {
-      result = cardano_redeemer_list_add(redeemers, rdmer);
-    }
-
-    cardano_redeemer_unref(&rdmer);
-  }
 
   return result;
 }
@@ -1215,111 +1090,11 @@ cardano_tx_builder_add_reference_input(
     return;
   }
 
-  if (utxo == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "UTXO is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
+  const cardano_error_t result = cardano_builder_add_reference_input(&builder->state, utxo, &error_message);
 
-  cardano_transaction_input_set_t* inputs = cardano_transaction_body_get_reference_inputs(body);
-
-  if (inputs == NULL)
-  {
-    cardano_error_t result = cardano_transaction_input_set_new(&inputs);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create reference inputs.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_transaction_body_set_reference_inputs(body, inputs);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set reference inputs.");
-      cardano_transaction_input_set_unref(&inputs);
-      builder->last_error = result;
-
-      return;
-    }
-  }
-
-  cardano_transaction_input_set_unref(&inputs);
-
-  cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
-  cardano_transaction_input_unref(&input);
-
-  cardano_error_t result = cardano_transaction_input_set_add(inputs, input);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add input to reference inputs.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_output_t* output = cardano_utxo_get_output(utxo);
-  cardano_transaction_output_unref(&output);
-
-  if (output == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Output is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_script_t* script = cardano_transaction_output_get_script_ref(output);
-  cardano_script_unref(&script);
-
-  if (script != NULL)
-  {
-    cardano_script_language_t language;
-    result = cardano_script_get_language(script, &language);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to get script language.");
-      builder->last_error = result;
-      return;
-    }
-
-    switch (language)
-    {
-      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V1:
-      {
-        builder->state.has_plutus_v1 = true;
-        break;
-      }
-      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V2:
-      {
-        builder->state.has_plutus_v2 = true;
-        break;
-      }
-      case CARDANO_SCRIPT_LANGUAGE_PLUTUS_V3:
-      {
-        builder->state.has_plutus_v3 = true;
-        break;
-      }
-      default:
-      {
-        break;
-      }
-    }
-  }
-
-  result = cardano_utxo_list_add(builder->state.reference_inputs, utxo);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add UTXO to reference inputs.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1333,39 +1108,11 @@ cardano_tx_builder_send_lovelace(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_output_t* output = NULL;
-  cardano_error_t               result = cardano_transaction_output_new(address, amount, &output);
+  const cardano_error_t result = cardano_builder_send_lovelace(&builder->state, address, amount, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create output.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
-  cardano_transaction_output_list_unref(&outputs);
-
-  result = cardano_transaction_output_list_add(outputs, output);
-  cardano_transaction_output_unref(&output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add output to transaction.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1380,25 +1127,11 @@ cardano_tx_builder_send_lovelace_ex(
     return;
   }
 
-  if ((address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_t* addr   = NULL;
-  cardano_error_t    result = cardano_address_from_string(address, address_size, &addr);
+  const cardano_error_t result = cardano_builder_send_lovelace_ex(&builder->state, address, address_size, amount, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_send_lovelace(builder, addr, amount);
-  cardano_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1412,56 +1145,11 @@ cardano_tx_builder_send_value(
     return;
   }
 
-  if (address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (value == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Value is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_send_value(&builder->state, address, value, &error_message);
 
-  cardano_transaction_output_t* output = NULL;
-  cardano_error_t               result = cardano_transaction_output_new(address, 0U, &output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create output.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_transaction_output_set_value(output, value);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set value.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
-  cardano_transaction_output_list_unref(&outputs);
-
-  result = cardano_transaction_output_list_add(outputs, output);
-  cardano_transaction_output_unref(&output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add output to transaction.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1476,32 +1164,11 @@ cardano_tx_builder_send_value_ex(
     return;
   }
 
-  if ((address == NULL) || (address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (value == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Value is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_send_value_ex(&builder->state, address, address_size, value, &error_message);
 
-  cardano_address_t* addr   = NULL;
-  cardano_error_t    result = cardano_address_from_string(address, address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_send_value(builder, addr, value);
-  cardano_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1516,48 +1183,11 @@ cardano_tx_builder_lock_lovelace(
     return;
   }
 
-  if (script_address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Script address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_output_t* output = NULL;
-  cardano_error_t               result = cardano_transaction_output_new(script_address, amount, &output);
+  const cardano_error_t result = cardano_builder_lock_lovelace(&builder->state, script_address, amount, datum, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create output.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_transaction_output_set_datum(output, datum);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set datum.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
-  cardano_transaction_output_list_unref(&outputs);
-
-  result = cardano_transaction_output_list_add(outputs, output);
-  cardano_transaction_output_unref(&output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add output to transaction.");
-    builder->last_error = result;
-    return;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1573,25 +1203,11 @@ cardano_tx_builder_lock_lovelace_ex(
     return;
   }
 
-  if ((script_address == NULL) || (script_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Script address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_t* addr   = NULL;
-  cardano_error_t    result = cardano_address_from_string(script_address, script_address_size, &addr);
+  const cardano_error_t result = cardano_builder_lock_lovelace_ex(&builder->state, script_address, script_address_size, amount, datum, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse script address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_lock_lovelace(builder, addr, amount, datum);
-  cardano_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1606,58 +1222,11 @@ cardano_tx_builder_lock_value(
     return;
   }
 
-  if (script_address == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Script address is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_output_t* output = NULL;
-  cardano_error_t               result = cardano_transaction_output_new(script_address, 0U, &output);
+  const cardano_error_t result = cardano_builder_lock_value(&builder->state, script_address, value, datum, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create output.");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_transaction_output_set_value(output, value);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set value.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
-
-  result = cardano_transaction_output_set_datum(output, datum);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set datum.");
-    builder->last_error = result;
-    cardano_transaction_output_unref(&output);
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
-  cardano_transaction_output_list_unref(&outputs);
-
-  result = cardano_transaction_output_list_add(outputs, output);
-  cardano_transaction_output_unref(&output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add output to transaction.");
-    builder->last_error = result;
-    return;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1673,101 +1242,11 @@ cardano_tx_builder_lock_value_ex(
     return;
   }
 
-  if ((script_address == NULL) || (script_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Script address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_address_t* addr   = NULL;
-  cardano_error_t    result = cardano_address_from_string(script_address, script_address_size, &addr);
+  const cardano_error_t result = cardano_builder_lock_value_ex(&builder->state, script_address, script_address_size, value, datum, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse script address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_lock_value(builder, addr, value, datum);
-  cardano_address_unref(&addr);
-}
-
-/**
- * \brief Creates the placeholder payload used by deferred redeemers until they are resolved.
- *
- * The placeholder is an empty constructor (constr 0 []), so the transaction can be sized and
- * hashed before the first balancing iteration replaces it with the real payload.
- *
- * \param[out] data The placeholder plutus data.
- *
- * \return \ref CARDANO_SUCCESS on success, or an appropriate error code.
- */
-static cardano_error_t
-create_placeholder_plutus_data(cardano_plutus_data_t** data)
-{
-  cardano_plutus_list_t* fields = NULL;
-
-  cardano_error_t result = cardano_plutus_list_new(&fields);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  cardano_constr_plutus_data_t* constr = NULL;
-
-  result = cardano_constr_plutus_data_new(0U, fields, &constr);
-
-  cardano_plutus_list_unref(&fields);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  result = cardano_plutus_data_new_constr(constr, data);
-
-  cardano_constr_plutus_data_unref(&constr);
-
-  return result;
-}
-
-/**
- * \brief Registers a deferred callback for the redeemer stored under the given hash in one of
- * the builder's redeemer maps.
- *
- * \param[in,out] builder      The transaction builder.
- * \param[in]     map          The map holding the redeemer (mint, withdrawal or vote map).
- * \param[in]     hash         The key of the redeemer in the map.
- * \param[in]     callback     The deferred redeemer callback.
- * \param[in]     user_context The opaque pointer forwarded to the callback.
- */
-static void
-register_deferred_from_map(
-  cardano_tx_builder_t*                   builder,
-  cardano_blake2b_hash_to_redeemer_map_t* map,
-  cardano_blake2b_hash_t*                 hash,
-  cardano_deferred_redeemer_fn_t          callback,
-  void*                                   user_context)
-{
-  cardano_redeemer_t* redeemer = NULL;
-
-  cardano_error_t result = cardano_blake2b_hash_to_redeemer_map_get(map, hash, &redeemer);
-
-  if (result == CARDANO_SUCCESS)
-  {
-    result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
-  }
-
-  cardano_redeemer_unref(&redeemer);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to register the deferred redeemer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1782,153 +1261,11 @@ cardano_tx_builder_add_input(
     return;
   }
 
-  if (utxo == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "UTXO is required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_transaction_output_t* output = cardano_utxo_get_output(utxo);
-  cardano_transaction_output_unref(&output);
+  const cardano_error_t result = cardano_builder_add_input(&builder->state, utxo, redeemer, datum, &error_message);
 
-  cardano_address_t* address = cardano_transaction_output_get_address(output);
-  cardano_address_unref(&address);
-
-  cardano_address_type_t address_type;
-
-  cardano_error_t result = cardano_address_get_type(address, &address_type);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to get address type");
-    builder->last_error = result;
-    return;
-  }
-
-  result = cardano_utxo_list_add(builder->state.pre_selected_inputs, utxo);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add UTXO to pre-selected inputs");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witnesses);
-
-  cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
-
-  if (redeemers == NULL)
-  {
-    result = cardano_redeemer_list_new(&redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create redeemers list");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_witness_set_set_redeemers(witnesses, redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set redeemers list");
-      cardano_redeemer_list_unref(&redeemers);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_redeemer_list_unref(&redeemers);
-
-  if (redeemer != NULL)
-  {
-    cardano_redeemer_t* rdmer = NULL;
-
-    cardano_ex_units_t* ex_units = NULL;
-    result                       = cardano_ex_units_new(0, 0, &ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create execution units");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_SPEND, 0, redeemer, ex_units, &rdmer);
-    cardano_ex_units_unref(&ex_units);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create redeemer");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_redeemer_list_add(redeemers, rdmer);
-    cardano_redeemer_unref(&rdmer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add redeemer to list");
-      builder->last_error = result;
-      return;
-    }
-
-    cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
-    cardano_transaction_input_unref(&input);
-
-    result = cardano_input_to_redeemer_map_insert(builder->state.input_to_redeemer_map, input, rdmer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to insert input to redeemer map");
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_plutus_data_set_t* datums = cardano_witness_set_get_plutus_data(witnesses);
-
-  if (datums == NULL)
-  {
-    result = cardano_plutus_data_set_new(&datums);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create datums set");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_witness_set_set_plutus_data(witnesses, datums);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set datums set");
-      cardano_plutus_data_set_unref(&datums);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_plutus_data_set_unref(&datums);
-
-  if (datum != NULL)
-  {
-    result = cardano_plutus_data_set_add(datums, datum);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add datum to set");
-      builder->last_error = result;
-      return;
-    }
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -1941,24 +1278,9 @@ cardano_tx_builder_add_output(
     return;
   }
 
-  if (output == NULL)
-  {
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_output(&builder->state, output);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
-  cardano_transaction_output_list_unref(&outputs);
-
-  cardano_error_t result = cardano_transaction_output_list_add(outputs, output);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, NULL);
 }
 
 void
@@ -2102,91 +1424,11 @@ cardano_tx_builder_mint_token(
     return;
   }
 
-  if (policy_id == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy ID is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_mint_token(&builder->state, policy_id, name, amount, redeemer, &error_message);
 
-  if (name == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Asset name is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_multi_asset_t* tokens = cardano_transaction_body_get_mint(body);
-
-  if (tokens == NULL)
-  {
-    cardano_error_t result = cardano_multi_asset_new(&tokens);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create multi-asset.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    result = cardano_transaction_body_set_mint(body, tokens);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set multi-asset.");
-      cardano_multi_asset_unref(&tokens);
-
-      builder->last_error = result;
-
-      return;
-    }
-  }
-
-  cardano_multi_asset_unref(&tokens);
-
-  cardano_error_t result = cardano_multi_asset_set(tokens, policy_id, name, amount);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to set multi-asset.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  if (redeemer != NULL)
-  {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-    cardano_witness_set_unref(&witnesses);
-
-    result = add_redeemer(witnesses, policy_id, redeemer, CARDANO_REDEEMER_TAG_MINT, builder);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add redeemer.");
-      builder->last_error = result;
-    }
-  }
-  else
-  {
-    // We still want to add an entry in the mints_to_redeemer_map with a NULL redeemer
-    // so it can compute the indices correctly.
-    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.mints_to_redeemer_map, policy_id, NULL);
-
-    // Avoid error on duplicated key, as it can happen when minting multiple assets
-    // under the same policy without redeemer.
-    if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add mint.");
-      builder->last_error = result;
-    }
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2204,49 +1446,11 @@ cardano_tx_builder_mint_token_ex(
     return;
   }
 
-  if ((policy_id_hex == NULL) || (policy_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_mint_token_ex(&builder->state, policy_id_hex, policy_id_size, name_hex, name_size, amount, redeemer, &error_message);
 
-  if ((name_hex == NULL) || (name_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Asset name is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-
-    return;
-  }
-
-  cardano_blake2b_hash_t* policy_id = NULL;
-  cardano_error_t         result    = cardano_blake2b_hash_from_hex(policy_id_hex, policy_id_size, &policy_id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse policy ID.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_asset_name_t* name = NULL;
-  result                     = cardano_asset_name_from_hex(name_hex, name_size, &name);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_blake2b_hash_unref(&policy_id);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse asset name.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_mint_token(builder, policy_id, name, amount, redeemer);
-
-  cardano_blake2b_hash_unref(&policy_id);
-  cardano_asset_name_unref(&name);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2261,21 +1465,11 @@ cardano_tx_builder_mint_token_with_id(
     return;
   }
 
-  if (asset_id == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Asset ID is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_mint_token_with_id(&builder->state, asset_id, amount, redeemer, &error_message);
 
-  cardano_blake2b_hash_t* policy_id = cardano_asset_id_get_policy_id(asset_id);
-  cardano_asset_name_t*   name      = cardano_asset_id_get_asset_name(asset_id);
-
-  cardano_blake2b_hash_unref(&policy_id);
-  cardano_asset_name_unref(&name);
-
-  cardano_tx_builder_mint_token(builder, policy_id, name, amount, redeemer);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2291,27 +1485,11 @@ cardano_tx_builder_mint_token_with_id_ex(
     return;
   }
 
-  if ((asset_id_hex == NULL) || (hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Asset ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_mint_token_with_id_ex(&builder->state, asset_id_hex, hex_size, amount, redeemer, &error_message);
 
-  cardano_asset_id_t* asset_id = NULL;
-  cardano_error_t     result   = cardano_asset_id_from_hex(asset_id_hex, hex_size, &asset_id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to parse asset ID.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_mint_token_with_id(builder, asset_id, amount, redeemer);
-  cardano_asset_id_unref(&asset_id);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2577,7 +1755,9 @@ cardano_tx_builder_withdraw_rewards(
     cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
-    result = add_redeemer(witnesses, hash, redeemer, CARDANO_REDEEMER_TAG_REWARD, builder);
+    const char* error_message = NULL;
+
+    result = cardano_builder_add_redeemer(witnesses, hash, redeemer, CARDANO_REDEEMER_TAG_REWARD, &builder->state, &error_message);
 
     cardano_blake2b_hash_unref(&hash);
 
@@ -3459,7 +2639,9 @@ cardano_tx_builder_vote(
     cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
     cardano_witness_set_unref(&witnesses);
 
-    result = add_redeemer(witnesses, id_hash, redeemer, CARDANO_REDEEMER_TAG_VOTING, builder);
+    const char* error_message = NULL;
+
+    result = cardano_builder_add_redeemer(witnesses, id_hash, redeemer, CARDANO_REDEEMER_TAG_VOTING, &builder->state, &error_message);
     cardano_blake2b_hash_unref(&id_hash);
 
     if (result != CARDANO_SUCCESS)
@@ -4924,54 +4106,11 @@ cardano_tx_builder_add_input_with_deferred_redeemer(
     return;
   }
 
-  if ((utxo == NULL) || (callback == NULL))
-  {
-    cardano_tx_builder_set_last_error(builder, "UTXO and callback are required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_add_input_with_deferred_redeemer(&builder->state, utxo, callback, user_context, datum, &error_message);
 
-  cardano_plutus_data_t* placeholder = NULL;
-
-  cardano_error_t result = create_placeholder_plutus_data(&placeholder);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create the placeholder redeemer.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_add_input(builder, utxo, placeholder, datum);
-
-  cardano_plutus_data_unref(&placeholder);
-
-  if (builder->last_error != CARDANO_SUCCESS)
-  {
-    return;
-  }
-
-  cardano_transaction_input_t* input = cardano_utxo_get_input(utxo);
-  cardano_transaction_input_unref(&input);
-
-  cardano_redeemer_t* redeemer = NULL;
-
-  result = cardano_input_to_redeemer_map_get(builder->state.input_to_redeemer_map, input, &redeemer);
-
-  if (result == CARDANO_SUCCESS)
-  {
-    result = cardano_deferred_redeemer_list_add(builder->state.deferred_redeemers, redeemer, callback, user_context);
-  }
-
-  cardano_redeemer_unref(&redeemer);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to register the deferred redeemer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -4988,36 +4127,11 @@ cardano_tx_builder_mint_token_with_deferred_redeemer(
     return;
   }
 
-  if ((policy_id == NULL) || (callback == NULL))
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy id and callback are required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
+  const char* error_message = NULL;
 
-    return;
-  }
+  const cardano_error_t result = cardano_builder_mint_token_with_deferred_redeemer(&builder->state, policy_id, name, amount, callback, user_context, &error_message);
 
-  cardano_plutus_data_t* placeholder = NULL;
-
-  cardano_error_t result = create_placeholder_plutus_data(&placeholder);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create the placeholder redeemer.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_mint_token(builder, policy_id, name, amount, placeholder);
-
-  cardano_plutus_data_unref(&placeholder);
-
-  if (builder->last_error != CARDANO_SUCCESS)
-  {
-    return;
-  }
-
-  register_deferred_from_map(builder, builder->state.mints_to_redeemer_map, policy_id, callback, user_context);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -5043,7 +4157,7 @@ cardano_tx_builder_withdraw_rewards_with_deferred_redeemer(
 
   cardano_plutus_data_t* placeholder = NULL;
 
-  cardano_error_t result = create_placeholder_plutus_data(&placeholder);
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -5077,7 +4191,11 @@ cardano_tx_builder_withdraw_rewards_with_deferred_redeemer(
     return;
   }
 
-  register_deferred_from_map(builder, builder->state.withdrawals_to_redeemer_map, hash, callback, user_context);
+  const char* error_message = NULL;
+
+  result = cardano_builder_register_deferred_from_map(&builder->state, builder->state.withdrawals_to_redeemer_map, hash, callback, user_context, &error_message);
+
+  track_builder_result(builder, result, error_message);
 
   cardano_blake2b_hash_unref(&hash);
 }
@@ -5104,7 +4222,7 @@ cardano_tx_builder_add_certificate_with_deferred_redeemer(
 
   cardano_plutus_data_t* placeholder = NULL;
 
-  cardano_error_t result = create_placeholder_plutus_data(&placeholder);
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -5195,7 +4313,7 @@ cardano_tx_builder_vote_with_deferred_redeemer(
 
   cardano_plutus_data_t* placeholder = NULL;
 
-  cardano_error_t result = create_placeholder_plutus_data(&placeholder);
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -5226,7 +4344,11 @@ cardano_tx_builder_vote_with_deferred_redeemer(
     return;
   }
 
-  register_deferred_from_map(builder, builder->state.votes_to_redeemer_map, hash, callback, user_context);
+  const char* error_message = NULL;
+
+  result = cardano_builder_register_deferred_from_map(&builder->state, builder->state.votes_to_redeemer_map, hash, callback, user_context, &error_message);
+
+  track_builder_result(builder, result, error_message);
 
   cardano_blake2b_hash_unref(&hash);
 }

--- a/lib/src/transaction_builder/transaction_builder.c
+++ b/lib/src/transaction_builder/transaction_builder.c
@@ -36,19 +36,13 @@
 #include "./internals/builder_inputs.h"
 #include "./internals/builder_mint.h"
 #include "./internals/builder_outputs.h"
+#include "./internals/builder_proposals.h"
 #include "./internals/builder_redeemers.h"
 #include "./internals/builder_state.h"
+#include "./internals/builder_votes.h"
 #include "./internals/builder_withdrawals.h"
 
 #include <assert.h>
-#include <cardano/proposal_procedures/constitution.h>
-#include <cardano/proposal_procedures/hard_fork_initiation_action.h>
-#include <cardano/proposal_procedures/info_action.h>
-#include <cardano/proposal_procedures/new_constitution_action.h>
-#include <cardano/proposal_procedures/no_confidence_action.h>
-#include <cardano/proposal_procedures/parameter_change_action.h>
-#include <cardano/proposal_procedures/treasury_withdrawals_action.h>
-#include <src/string_safe.h>
 
 /* STRUCTURES ****************************************************************/
 
@@ -334,229 +328,6 @@ update_script_data_hash(cardano_tx_builder_t* builder, cardano_transaction_t* tx
   cardano_blake2b_hash_unref(&hash);
 
   return result;
-}
-
-/**
- * \brief Gets the proposal procedures set from the transaction body. If there are no proposal
- * procedures set, it creates a new list.
- *
- * \param builder The transaction builder.
- * \param body The transaction body.
- *
- * \return The proposal procedures set.
- */
-static cardano_proposal_procedure_set_t*
-get_proposal_procedure_set(cardano_tx_builder_t* builder, cardano_transaction_body_t* body)
-{
-  cardano_proposal_procedure_set_t* proposals = cardano_transaction_body_get_proposal_procedures(body);
-
-  if (proposals == NULL)
-  {
-    cardano_error_t result = cardano_proposal_procedure_set_new(&proposals);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure set.");
-      builder->last_error = result;
-
-      return NULL;
-    }
-
-    result = cardano_transaction_body_set_proposal_procedure(body, proposals);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set proposal procedure set.");
-      cardano_proposal_procedure_set_unref(&proposals);
-      builder->last_error = result;
-
-      return NULL;
-    }
-  }
-
-  cardano_proposal_procedure_set_unref(&proposals);
-
-  return proposals;
-}
-
-/**
- * \brief Creates an empty plutus data object.
- *
- * \return The empty plutus data object.
- */
-static cardano_plutus_data_t*
-create_empty_plutus_data(void)
-{
-  static const char* VOID_DATA = "d87980";
-
-  cardano_plutus_data_t* plutus_data = NULL;
-  cardano_cbor_reader_t* reader      = cardano_cbor_reader_from_hex(VOID_DATA, cardano_safe_strlen(VOID_DATA, 6));
-
-  cardano_error_t result = cardano_plutus_data_from_cbor(reader, &plutus_data);
-  cardano_cbor_reader_unref(&reader);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return NULL;
-  }
-
-  return plutus_data;
-}
-
-/**
- * \brief Adds an empty proposing redeemer to the witness set.
- *
- * \param builder The transaction builder.
- * \param witness_set The witness set.
- * \param proposal_index The index of the proposal that requires the redeemer.
- *
- * \return The result of the operation.
- */
-static cardano_error_t
-add_proposing_redeemer(
-  cardano_tx_builder_t*  builder,
-  cardano_witness_set_t* witness_set,
-  const size_t           proposal_index)
-{
-  cardano_redeemer_list_t* redeemers         = cardano_witness_set_get_redeemers(witness_set);
-  cardano_plutus_data_t*   empty_plutus_data = create_empty_plutus_data();
-  cardano_redeemer_t*      rdmer             = NULL;
-  cardano_ex_units_t*      ex_units          = NULL;
-
-  cardano_error_t result = cardano_ex_units_new(0, 0, &ex_units);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_plutus_data_unref(&empty_plutus_data);
-    return result;
-  }
-
-  result = cardano_redeemer_new(CARDANO_REDEEMER_TAG_PROPOSING, proposal_index, empty_plutus_data, ex_units, &rdmer);
-
-  cardano_plutus_data_unref(&empty_plutus_data);
-  cardano_ex_units_unref(&ex_units);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  if (redeemers == NULL)
-  {
-    result = cardano_redeemer_list_new(&redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_redeemer_unref(&rdmer);
-      cardano_tx_builder_set_last_error(builder, "Failed to create redeemer list.");
-      builder->last_error = result;
-
-      return result;
-    }
-
-    result = cardano_witness_set_set_redeemers(witness_set, redeemers);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_redeemer_unref(&rdmer);
-      cardano_tx_builder_set_last_error(builder, "Failed to set redeemer list.");
-      cardano_redeemer_list_unref(&redeemers);
-      builder->last_error = result;
-
-      return result;
-    }
-  }
-
-  cardano_redeemer_list_unref(&redeemers);
-
-  result = cardano_redeemer_list_add(redeemers, rdmer);
-  cardano_redeemer_unref(&rdmer);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add redeemer.");
-    builder->last_error = result;
-  }
-
-  return result;
-}
-
-/**
- * @brief Computes a deterministic, sortable hash ID for a voter.
- *
- * This function creates an identifier by concatenating the voter's type and credential hash.
- *
- * This ID can be used to establish a canonical sorting order for a voter's redeemer.
- *
- * @param[in] voter A pointer to the `cardano_voter_t` object.
- * @param[out] id On success, this will be populated with a pointer to a newly allocated
- * `cardano_blake2b_hash_t` object representing the unique ID.
- *
- * @return `CARDANO_SUCCESS` if the ID was computed successfully. Returns an appropriate
- * error code on failure.
- *
- * @note The caller is responsible for managing the lifecycle of the returned `id` object
- * and must release it by calling `cardano_blake2b_hash_unref`.
- */
-static cardano_error_t
-compute_voting_procedures_sortable_id(cardano_voter_t* voter, cardano_blake2b_hash_t** id)
-{
-  if ((id == NULL) || (voter == NULL))
-  {
-    return CARDANO_ERROR_INVALID_ARGUMENT;
-  }
-
-  cardano_error_t result = CARDANO_SUCCESS;
-
-  cardano_credential_t*   credential = cardano_voter_get_credential(voter);
-  cardano_blake2b_hash_t* hash       = cardano_credential_get_hash(credential);
-
-  const byte_t* hash_bytes = cardano_blake2b_hash_get_data(hash);
-  size_t        hash_size  = cardano_blake2b_hash_get_bytes_size(hash);
-
-  cardano_voter_type_t voter_type;
-  result = cardano_voter_get_type(voter, &voter_type);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_blake2b_hash_unref(&hash);
-    cardano_credential_unref(&credential);
-    return result;
-  }
-
-  const size_t total_size = sizeof(voter_type) + hash_size;
-  byte_t*      id_bytes   = (byte_t*)_cardano_malloc(total_size);
-
-  if (id_bytes == NULL)
-  {
-    cardano_blake2b_hash_unref(&hash);
-    cardano_credential_unref(&credential);
-    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
-  }
-
-  size_t cursor = 0;
-
-  cardano_safe_memcpy(&id_bytes[cursor], total_size, &voter_type, sizeof(voter_type));
-  cursor += sizeof(voter_type);
-
-  cardano_safe_memcpy(&id_bytes[cursor], total_size - cursor, hash_bytes, hash_size);
-
-  cardano_blake2b_hash_unref(&hash);
-  cardano_credential_unref(&credential);
-
-  cardano_blake2b_hash_t* id_hash = NULL;
-  result                          = cardano_blake2b_hash_from_bytes(id_bytes, total_size, &id_hash);
-
-  _cardano_free(id_bytes);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    return result;
-  }
-
-  *id = id_hash;
-
-  return CARDANO_SUCCESS;
 }
 
 /* DEFINITIONS ****************************************************************/
@@ -1931,106 +1702,11 @@ cardano_tx_builder_vote(
     return;
   }
 
-  if (voter == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Voter is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if (action_id == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Action ID is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_vote(&builder->state, voter, action_id, vote, redeemer, &error_message);
 
-  if (vote == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Vote is NULL.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_voting_procedures_t* votes = cardano_transaction_body_get_voting_procedures(body);
-
-  if (votes == NULL)
-  {
-    cardano_error_t result = cardano_voting_procedures_new(&votes);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to create voting procedures.");
-      builder->last_error = result;
-      return;
-    }
-
-    result = cardano_transaction_body_set_voting_procedures(body, votes);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to set voting procedures.");
-      cardano_voting_procedures_unref(&votes);
-      builder->last_error = result;
-      return;
-    }
-  }
-
-  cardano_voting_procedures_unref(&votes);
-
-  cardano_error_t result = cardano_voting_procedures_insert(votes, voter, action_id, vote);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to insert vote.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_blake2b_hash_t* id_hash = NULL;
-  result                          = compute_voting_procedures_sortable_id(voter, &id_hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create voting procedure ID hash.");
-    builder->last_error = result;
-    return;
-  }
-
-  if (redeemer != NULL)
-  {
-    cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-    cardano_witness_set_unref(&witnesses);
-
-    const char* error_message = NULL;
-
-    result = cardano_builder_add_redeemer(witnesses, id_hash, redeemer, CARDANO_REDEEMER_TAG_VOTING, &builder->state, &error_message);
-    cardano_blake2b_hash_unref(&id_hash);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      cardano_tx_builder_set_last_error(builder, "Failed to add redeemer.");
-      builder->last_error = result;
-    }
-  }
-  else
-  {
-    result = cardano_blake2b_hash_to_redeemer_map_insert(builder->state.votes_to_redeemer_map, id_hash, NULL);
-
-    if ((result != CARDANO_SUCCESS) && (result != CARDANO_ERROR_DUPLICATED_KEY))
-    {
-      cardano_blake2b_hash_unref(&id_hash);
-      cardano_tx_builder_set_last_error(builder, "Failed to add vote redeemer placeholder.");
-      builder->last_error = result;
-
-      return;
-    }
-
-    cardano_blake2b_hash_unref(&id_hash);
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2129,63 +1805,11 @@ cardano_tx_builder_propose_parameter_change(
     return;
   }
 
-  if (policy_hash == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy hash is NULL. You must provide the constitution script hash.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_parameter_change_action_t* action = NULL;
-  cardano_error_t                    result = cardano_parameter_change_action_new(protocol_param_update, governance_action_id, policy_hash, &action);
+  const cardano_error_t result = cardano_builder_propose_parameter_change(&builder->state, reward_address, anchor, protocol_param_update, governance_action_id, policy_hash, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create parameter change action.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_parameter_change_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_parameter_change_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
-
-  cardano_proposal_procedure_unref(&proposal);
-
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witnesses);
-  const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
-
-  result = add_proposing_redeemer(builder, witnesses, proposal_index);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposing redeemer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2208,100 +1832,11 @@ cardano_tx_builder_propose_parameter_change_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_parameter_change_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, gov_action_id, gov_action_id_size, policy_hash_hash_hex, policy_hash_hash_hex_size, protocol_param_update, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Governance action ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((policy_hash_hash_hex == NULL) || (policy_hash_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_governance_action_id_t* id = NULL;
-
-  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse governance action ID.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_blake2b_hash_t* policy_hash = NULL;
-
-  result = cardano_blake2b_hash_from_hex(policy_hash_hash_hex, policy_hash_hash_hex_size, &policy_hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_governance_action_id_unref(&id);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse policy hash.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_propose_parameter_change(builder, addr, anchor, protocol_param_update, id, policy_hash);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_governance_action_id_unref(&id);
-  cardano_blake2b_hash_unref(&policy_hash);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2317,43 +1852,11 @@ cardano_tx_builder_propose_hardfork(
     return;
   }
 
-  cardano_hard_fork_initiation_action_t* action = NULL;
-  cardano_error_t                        result = cardano_hard_fork_initiation_action_new(version, governance_action_id, &action);
+  const char* error_message = NULL;
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create hard fork action.");
-    builder->last_error = result;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_hardfork(&builder->state, reward_address, anchor, version, governance_action_id, &error_message);
 
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_hard_fork_initiation_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_hard_fork_initiation_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2375,88 +1878,11 @@ cardano_tx_builder_propose_hardfork_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_hardfork_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, gov_action_id, gov_action_id_size, minor_protocol_version, major_protocol_version, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Governance action ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_governance_action_id_t* id = NULL;
-
-  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse governance action ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_protocol_version_t* version = NULL;
-  result                              = cardano_protocol_version_new(minor_protocol_version, major_protocol_version, &version);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_governance_action_id_unref(&id);
-    cardano_tx_builder_set_last_error(builder, "Failed to create protocol version.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_propose_hardfork(builder, addr, anchor, version, id);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_governance_action_id_unref(&id);
-  cardano_protocol_version_unref(&version);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2472,62 +1898,11 @@ cardano_tx_builder_propose_treasury_withdrawals(
     return;
   }
 
-  if (policy_hash == NULL)
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy hash is NULL. You must provide the constitution script hash.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  cardano_treasury_withdrawals_action_t* action = NULL;
-  cardano_error_t                        result = cardano_treasury_withdrawals_action_new(withdrawals, policy_hash, &action);
+  const cardano_error_t result = cardano_builder_propose_treasury_withdrawals(&builder->state, reward_address, anchor, withdrawals, policy_hash, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create treasury withdrawal action.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_treasury_withdrawals_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_treasury_withdrawals_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
-
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(builder->state.transaction);
-  cardano_witness_set_unref(&witnesses);
-  const size_t proposal_index = cardano_proposal_procedure_set_get_length(proposals) - 1U;
-
-  result = add_proposing_redeemer(builder, witnesses, proposal_index);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposing redeemer.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2548,73 +1923,11 @@ cardano_tx_builder_propose_treasury_withdrawals_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_treasury_withdrawals_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, policy_hash_hash_hex, policy_hash_hash_hex_size, withdrawals, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((policy_hash_hash_hex == NULL) || (policy_hash_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Policy hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_blake2b_hash_t* policy_hash = NULL;
-  result                              = cardano_blake2b_hash_from_hex(policy_hash_hash_hex, policy_hash_hash_hex_size, &policy_hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse policy hash.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_propose_treasury_withdrawals(builder, addr, anchor, withdrawals, policy_hash);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_blake2b_hash_unref(&policy_hash);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2629,42 +1942,11 @@ cardano_tx_builder_propose_no_confidence(
     return;
   }
 
-  cardano_no_confidence_action_t* action = NULL;
-  cardano_error_t                 result = cardano_no_confidence_action_new(governance_action_id, &action);
+  const char* error_message = NULL;
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create no confidence action.");
-    builder->last_error = result;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_no_confidence(&builder->state, reward_address, anchor, governance_action_id, &error_message);
 
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_no_confidence_action(deposit, reward_address, anchor, action, &proposal);
-  cardano_no_confidence_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2684,74 +1966,11 @@ cardano_tx_builder_propose_no_confidence_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_no_confidence_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, gov_action_id, gov_action_id_size, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Governance action ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_governance_action_id_t* id = NULL;
-
-  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse governance action ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_propose_no_confidence(builder, addr, anchor, id);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_governance_action_id_unref(&id);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2769,44 +1988,11 @@ cardano_tx_builder_propose_update_committee(
     return;
   }
 
-  cardano_update_committee_action_t* action = NULL;
-  cardano_error_t                    result = cardano_update_committee_action_new(members_to_be_removed, members_to_be_added, new_quorum, governance_action_id, &action);
+  const char* error_message = NULL;
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create update committee action.");
-    builder->last_error = result;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_update_committee(&builder->state, reward_address, anchor, governance_action_id, members_to_be_removed, members_to_be_added, new_quorum, &error_message);
 
-  cardano_proposal_procedure_t* proposal;
-
-  const uint64_t deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_update_committee_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_update_committee_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2829,89 +2015,11 @@ cardano_tx_builder_propose_update_committee_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_update_committee_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, gov_action_id, gov_action_id_size, members_to_be_removed, members_to_be_added, new_quorum, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Governance action ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-  result                         = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_governance_action_id_t* id = NULL;
-
-  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse governance action ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_unit_interval_t* quorum = NULL;
-  result                          = cardano_unit_interval_from_double(new_quorum, &quorum);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_governance_action_id_unref(&id);
-    cardano_tx_builder_set_last_error(builder, "Failed to create unit interval.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_propose_update_committee(builder, addr, anchor, id, members_to_be_removed, members_to_be_added, quorum);
-
-  cardano_unit_interval_unref(&quorum);
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_governance_action_id_unref(&id);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2927,44 +2035,11 @@ cardano_tx_builder_propose_new_constitution(
     return;
   }
 
-  cardano_new_constitution_action_t* action = NULL;
+  const char* error_message = NULL;
 
-  cardano_error_t result = cardano_new_constitution_action_new(constitution, governance_action_id, &action);
+  const cardano_error_t result = cardano_builder_propose_new_constitution(&builder->state, reward_address, anchor, governance_action_id, constitution, &error_message);
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create new constitution action.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_constitution_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_new_constitution_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -2985,75 +2060,11 @@ cardano_tx_builder_propose_new_constitution_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_new_constitution_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, gov_action_id, gov_action_id_size, constitution, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  if ((gov_action_id == NULL) || (gov_action_id_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Governance action ID is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-
-  result = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_governance_action_id_t* id = NULL;
-
-  result = cardano_governance_action_id_from_bech32(gov_action_id, gov_action_id_size, &id);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_reward_address_unref(&addr);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse governance action ID.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_propose_new_constitution(builder, addr, anchor, id, constitution);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
-  cardano_governance_action_id_unref(&id);
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -3067,44 +2078,11 @@ cardano_tx_builder_propose_info(
     return;
   }
 
-  cardano_info_action_t* action = NULL;
-  cardano_error_t        result = cardano_info_action_new(&action);
+  const char* error_message = NULL;
 
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create info action.");
-    builder->last_error = result;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_info(&builder->state, reward_address, anchor, &error_message);
 
-  cardano_proposal_procedure_t* proposal;
-  const uint64_t                deposit = cardano_protocol_parameters_get_governance_action_deposit(builder->state.params);
-
-  result = cardano_proposal_procedure_new_info_action(deposit, reward_address, anchor, action, &proposal);
-
-  cardano_info_action_unref(&action);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create proposal procedure.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
-  cardano_transaction_body_unref(&body);
-
-  cardano_proposal_procedure_set_t* proposals = get_proposal_procedure_set(builder, body);
-
-  result = cardano_proposal_procedure_set_add(proposals, proposal);
-
-  cardano_proposal_procedure_unref(&proposal);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to add proposal procedure.");
-    builder->last_error = result;
-  }
+  track_builder_result(builder, result, error_message);
 }
 
 void
@@ -3122,54 +2100,11 @@ cardano_tx_builder_propose_info_ex(
     return;
   }
 
-  if ((reward_address == NULL) || (reward_address_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Reward address is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const char* error_message = NULL;
 
-  if ((metadata_url == NULL) || (metadata_url_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata URL is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
+  const cardano_error_t result = cardano_builder_propose_info_ex(&builder->state, reward_address, reward_address_size, metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &error_message);
 
-  if ((metadata_hash_hex == NULL) || (metadata_hash_hex_size == 0U))
-  {
-    cardano_tx_builder_set_last_error(builder, "Metadata hash is NULL or empty.");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-    return;
-  }
-
-  cardano_anchor_t* anchor = NULL;
-
-  cardano_error_t result = cardano_anchor_from_hash_hex(metadata_url, metadata_url_size, metadata_hash_hex, metadata_hash_hex_size, &anchor);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create anchor.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_reward_address_t* addr = NULL;
-
-  result = cardano_reward_address_from_bech32(reward_address, reward_address_size, &addr);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_anchor_unref(&anchor);
-    cardano_tx_builder_set_last_error(builder, "Failed to parse reward address.");
-    builder->last_error = result;
-    return;
-  }
-
-  cardano_tx_builder_propose_info(builder, addr, anchor);
-
-  cardano_anchor_unref(&anchor);
-  cardano_reward_address_unref(&addr);
+  track_builder_result(builder, result, error_message);
 }
 
 cardano_error_t
@@ -3433,52 +2368,9 @@ cardano_tx_builder_vote_with_deferred_redeemer(
     return;
   }
 
-  if ((voter == NULL) || (action_id == NULL) || (vote == NULL) || (callback == NULL))
-  {
-    cardano_tx_builder_set_last_error(builder, "Voter, action id, vote and callback are required");
-    builder->last_error = CARDANO_ERROR_POINTER_IS_NULL;
-
-    return;
-  }
-
-  cardano_plutus_data_t* placeholder = NULL;
-
-  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&placeholder);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to create the placeholder redeemer.");
-    builder->last_error = result;
-
-    return;
-  }
-
-  cardano_tx_builder_vote(builder, voter, action_id, vote, placeholder);
-
-  cardano_plutus_data_unref(&placeholder);
-
-  if (builder->last_error != CARDANO_SUCCESS)
-  {
-    return;
-  }
-
-  cardano_blake2b_hash_t* hash = NULL;
-
-  result = compute_voting_procedures_sortable_id(voter, &hash);
-
-  if (result != CARDANO_SUCCESS)
-  {
-    cardano_tx_builder_set_last_error(builder, "Failed to compute the vote sortable id.");
-    builder->last_error = result;
-
-    return;
-  }
-
   const char* error_message = NULL;
 
-  result = cardano_builder_register_deferred_from_map(&builder->state, builder->state.votes_to_redeemer_map, hash, callback, user_context, &error_message);
+  const cardano_error_t result = cardano_builder_vote_with_deferred_redeemer(&builder->state, voter, action_id, vote, callback, user_context, &error_message);
 
   track_builder_result(builder, result, error_message);
-
-  cardano_blake2b_hash_unref(&hash);
 }

--- a/lib/tests/transaction_builder/internals/builder_redeemers.cpp
+++ b/lib/tests/transaction_builder/internals/builder_redeemers.cpp
@@ -1,0 +1,233 @@
+/**
+ * \file builder_redeemers.cpp
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * \section LICENSE
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+#include <cardano/plutus_data/constr_plutus_data.h>
+#include <cardano/plutus_data/plutus_list.h>
+
+#include "../../../src/transaction_builder/internals/builder_redeemers.h"
+
+#include "../../allocators_helpers.h"
+#include "../src/allocators.h"
+
+#include <gmock/gmock.h>
+
+/* CONSTANTS *****************************************************************/
+
+static const char* COSTMDLS_ALL_CBOR = "a30098a61a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0374f693194a1f0a0198af1a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a0011b22c1a0005fdde00021a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0223accc0a1a0374f693194a1f0a1a02515e841980b30a0298b31a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a0011b22c1a0005fdde00021a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0223accc0a1a0374f693194a1f0a1a02515e841980b30a01020304";
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * Creates a new default instance of the protocol parameters.
+ * @return A new instance of the protocol parameters.
+ */
+static cardano_protocol_parameters_t*
+init_protocol_parameters()
+{
+  cardano_protocol_parameters_t* params = NULL;
+
+  cardano_error_t result = cardano_protocol_parameters_new(&params);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  cardano_cbor_reader_t* reader = cardano_cbor_reader_from_hex(COSTMDLS_ALL_CBOR, strlen(COSTMDLS_ALL_CBOR));
+
+  cardano_costmdls_t* costmdls = NULL;
+  result                       = cardano_costmdls_from_cbor(reader, &costmdls);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  result = cardano_protocol_parameters_set_cost_models(params, costmdls);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  cardano_cbor_reader_unref(&reader);
+  cardano_costmdls_unref(&costmdls);
+
+  return params;
+}
+
+/**
+ * Creates a new blake2b hash filled with zero bytes.
+ * @return A new instance of the hash.
+ */
+static cardano_blake2b_hash_t*
+new_default_hash()
+{
+  static const byte_t bytes[28] = { 0 };
+
+  cardano_blake2b_hash_t* hash = NULL;
+
+  EXPECT_EQ(cardano_blake2b_hash_from_bytes(bytes, sizeof(bytes), &hash), CARDANO_SUCCESS);
+
+  return hash;
+}
+
+/**
+ * Deferred redeemer callback that never produces a payload.
+ * @return Always returns CARDANO_SUCCESS.
+ */
+static cardano_error_t
+noop_deferred_redeemer(
+  void*                   user_context,
+  cardano_transaction_t*  draft_tx,
+  cardano_utxo_list_t*    resolved_inputs,
+  cardano_plutus_data_t** redeemer)
+{
+  CARDANO_UNUSED(user_context);
+  CARDANO_UNUSED(draft_tx);
+  CARDANO_UNUSED(resolved_inputs);
+  CARDANO_UNUSED(redeemer);
+
+  return CARDANO_SUCCESS;
+}
+
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_builder_add_redeemer, rejectsUnsupportedTags)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG), CARDANO_SUCCESS);
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state.transaction);
+  cardano_witness_set_unref(&witnesses);
+
+  cardano_blake2b_hash_t* hash = new_default_hash();
+  cardano_plutus_data_t*  data = NULL;
+
+  EXPECT_EQ(cardano_plutus_data_new_integer_from_int(0, &data), CARDANO_SUCCESS);
+
+  const char* error_message = NULL;
+
+  // Act
+  cardano_error_t spend_result = cardano_builder_add_redeemer(witnesses, hash, data, CARDANO_REDEEMER_TAG_SPEND, &state, &error_message);
+  cardano_error_t cert_result  = cardano_builder_add_redeemer(witnesses, hash, data, CARDANO_REDEEMER_TAG_CERTIFYING, &state, &error_message);
+
+  // Assert
+  EXPECT_EQ(spend_result, CARDANO_ERROR_ILLEGAL_STATE);
+  EXPECT_EQ(cert_result, CARDANO_ERROR_ILLEGAL_STATE);
+  EXPECT_STREQ(error_message, "Invalid redeemer tag.");
+
+  // Cleanup
+  cardano_plutus_data_unref(&data);
+  cardano_blake2b_hash_unref(&hash);
+  cardano_builder_state_release(&state);
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_add_redeemer, doesNothingWhenDataIsNull)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG), CARDANO_SUCCESS);
+
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(state.transaction);
+  cardano_witness_set_unref(&witnesses);
+
+  cardano_blake2b_hash_t* hash = new_default_hash();
+
+  const char* error_message = NULL;
+
+  // Act
+  cardano_error_t result = cardano_builder_add_redeemer(witnesses, hash, NULL, CARDANO_REDEEMER_TAG_MINT, &state, &error_message);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+  EXPECT_EQ(error_message, (const char*)NULL);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(state.mints_to_redeemer_map), 0U);
+
+  // Cleanup
+  cardano_blake2b_hash_unref(&hash);
+  cardano_builder_state_release(&state);
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_create_placeholder_plutus_data, createsAnEmptyConstr)
+{
+  // Arrange
+  cardano_plutus_data_t* data = NULL;
+
+  // Act
+  cardano_error_t result = cardano_builder_create_placeholder_plutus_data(&data);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  cardano_plutus_data_kind_t kind;
+
+  EXPECT_EQ(cardano_plutus_data_get_kind(data, &kind), CARDANO_SUCCESS);
+  EXPECT_EQ(kind, CARDANO_PLUTUS_DATA_KIND_CONSTR);
+
+  cardano_constr_plutus_data_t* constr = NULL;
+
+  EXPECT_EQ(cardano_plutus_data_to_constr(data, &constr), CARDANO_SUCCESS);
+
+  uint64_t alternative = 99U;
+
+  EXPECT_EQ(cardano_constr_plutus_data_get_alternative(constr, &alternative), CARDANO_SUCCESS);
+  EXPECT_EQ(alternative, 0U);
+
+  cardano_plutus_list_t* fields = NULL;
+
+  EXPECT_EQ(cardano_constr_plutus_data_get_data(constr, &fields), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_plutus_list_get_length(fields), 0U);
+
+  // Cleanup
+  cardano_plutus_list_unref(&fields);
+  cardano_constr_plutus_data_unref(&constr);
+  cardano_plutus_data_unref(&data);
+}
+
+TEST(cardano_builder_register_deferred_from_map, reportsMissingRedeemers)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG), CARDANO_SUCCESS);
+
+  cardano_blake2b_hash_t* hash = new_default_hash();
+
+  const char* error_message = NULL;
+
+  // Act
+  cardano_error_t result = cardano_builder_register_deferred_from_map(&state, state.mints_to_redeemer_map, hash, noop_deferred_redeemer, NULL, &error_message);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_ELEMENT_NOT_FOUND);
+  EXPECT_STREQ(error_message, "Failed to register the deferred redeemer.");
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(state.deferred_redeemers), 0U);
+
+  // Cleanup
+  cardano_blake2b_hash_unref(&hash);
+  cardano_builder_state_release(&state);
+  cardano_protocol_parameters_unref(&params);
+}

--- a/lib/tests/transaction_builder/internals/builder_state.cpp
+++ b/lib/tests/transaction_builder/internals/builder_state.cpp
@@ -1,0 +1,284 @@
+/**
+ * \file builder_state.cpp
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * \section LICENSE
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/error.h>
+
+#include "../../../src/transaction_builder/internals/builder_state.h"
+
+#include "../../allocators_helpers.h"
+#include "../src/allocators.h"
+
+#include <gmock/gmock.h>
+
+/* CONSTANTS *****************************************************************/
+
+static const char* COSTMDLS_ALL_CBOR = "a30098a61a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0374f693194a1f0a0198af1a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a0011b22c1a0005fdde00021a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0223accc0a1a0374f693194a1f0a1a02515e841980b30a0298b31a0003236119032c01011903e819023b00011903e8195e7104011903e818201a0001ca761928eb041959d818641959d818641959d818641959d818641959d818641959d81864186418641959d81864194c5118201a0002acfa182019b551041a000363151901ff00011a00015c3518201a000797751936f404021a0002ff941a0006ea7818dc0001011903e8196ff604021a0003bd081a00034ec5183e011a00102e0f19312a011a00032e801901a5011a0002da781903e819cf06011a00013a34182019a8f118201903e818201a00013aac0119e143041903e80a1a00030219189c011a00030219189c011a0003207c1901d9011a000330001901ff0119ccf3182019fd40182019ffd5182019581e18201940b318201a00012adf18201a0002ff941a0006ea7818dc0001011a00010f92192da7000119eabb18201a0002ff941a0006ea7818dc0001011a0002ff941a0006ea7818dc0001011a0011b22c1a0005fdde00021a000c504e197712041a001d6af61a0001425b041a00040c660004001a00014fab18201a0003236119032c010119a0de18201a00033d7618201979f41820197fb8182019a95d1820197df718201995aa18201a0223accc0a1a0374f693194a1f0a1a02515e841980b30a01020304";
+
+/* STATIC FUNCTIONS **********************************************************/
+
+/**
+ * Creates a new default instance of the protocol parameters.
+ * @return A new instance of the protocol parameters.
+ */
+static cardano_protocol_parameters_t*
+init_protocol_parameters()
+{
+  cardano_protocol_parameters_t* params = NULL;
+
+  cardano_error_t result = cardano_protocol_parameters_new(&params);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  cardano_cbor_reader_t* reader = cardano_cbor_reader_from_hex(COSTMDLS_ALL_CBOR, strlen(COSTMDLS_ALL_CBOR));
+
+  cardano_costmdls_t* costmdls = NULL;
+  result                       = cardano_costmdls_from_cbor(reader, &costmdls);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  result = cardano_protocol_parameters_set_cost_models(params, costmdls);
+
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  cardano_cbor_reader_unref(&reader);
+  cardano_costmdls_unref(&costmdls);
+
+  return params;
+}
+
+/* UNIT TESTS ****************************************************************/
+
+TEST(cardano_builder_state_init, canInitializeState)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+
+  EXPECT_THAT(state.transaction, testing::Not((cardano_transaction_t*)nullptr));
+  EXPECT_EQ(state.params, params);
+  EXPECT_THAT(state.coin_selector, testing::Not((cardano_coin_selector_t*)nullptr));
+  EXPECT_THAT(state.tx_evaluator, testing::Not((cardano_tx_evaluator_t*)nullptr));
+  EXPECT_EQ(state.change_address, (cardano_address_t*)nullptr);
+  EXPECT_EQ(state.collateral_address, (cardano_address_t*)nullptr);
+  EXPECT_EQ(state.available_utxos, (cardano_utxo_list_t*)nullptr);
+  EXPECT_EQ(state.collateral_utxos, (cardano_utxo_list_t*)nullptr);
+  EXPECT_THAT(state.pre_selected_inputs, testing::Not((cardano_utxo_list_t*)nullptr));
+  EXPECT_THAT(state.reference_inputs, testing::Not((cardano_utxo_list_t*)nullptr));
+  EXPECT_FALSE(state.has_plutus_v1);
+  EXPECT_FALSE(state.has_plutus_v2);
+  EXPECT_FALSE(state.has_plutus_v3);
+  EXPECT_EQ(state.additional_signature_count, 0U);
+  EXPECT_THAT(state.input_to_redeemer_map, testing::Not((cardano_input_to_redeemer_map_t*)nullptr));
+  EXPECT_THAT(state.withdrawals_to_redeemer_map, testing::Not((cardano_blake2b_hash_to_redeemer_map_t*)nullptr));
+  EXPECT_THAT(state.mints_to_redeemer_map, testing::Not((cardano_blake2b_hash_to_redeemer_map_t*)nullptr));
+  EXPECT_THAT(state.votes_to_redeemer_map, testing::Not((cardano_blake2b_hash_to_redeemer_map_t*)nullptr));
+  EXPECT_THAT(state.deferred_redeemers, testing::Not((cardano_deferred_redeemer_list_t*)nullptr));
+
+  EXPECT_EQ(state.slot_config.zero_time, CARDANO_MAINNET_SLOT_CONFIG.zero_time);
+  EXPECT_EQ(state.slot_config.zero_slot, CARDANO_MAINNET_SLOT_CONFIG.zero_slot);
+  EXPECT_EQ(state.slot_config.slot_length, CARDANO_MAINNET_SLOT_CONFIG.slot_length);
+
+  // Cleanup
+  cardano_builder_state_release(&state);
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_init, takesReferenceOnProtocolParameters)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 1U);
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 2U);
+
+  cardano_builder_state_release(&state);
+
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 1U);
+
+  // Cleanup
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_init, returnsErrorIfStateIsNull)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(nullptr, params, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
+
+  // Cleanup
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_init, returnsErrorIfParamsIsNull)
+{
+  // Arrange
+  cardano_builder_state_t state = {};
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, nullptr, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
+}
+
+TEST(cardano_builder_state_init, returnsErrorIfSlotConfigIsNull)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, params, nullptr);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_POINTER_IS_NULL);
+
+  // Cleanup
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_init, returnsErrorIfMemoryAllocationFails)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_right_away_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_MEMORY_ALLOCATION_FAILED);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+  cardano_builder_state_release(&state);
+
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 1U);
+
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_init, returnsErrorIfEventualMemoryAllocationFails)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  reset_allocators_run_count();
+  cardano_set_allocators(fail_after_one_malloc, realloc, free);
+
+  // Act
+  cardano_error_t result = cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG);
+
+  // Assert
+  EXPECT_EQ(result, CARDANO_ERROR_MEMORY_ALLOCATION_FAILED);
+
+  // Cleanup
+  cardano_set_allocators(malloc, realloc, free);
+  cardano_builder_state_release(&state);
+
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 1U);
+
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_release, setsHeldObjectPointersToNull)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG), CARDANO_SUCCESS);
+
+  // Act
+  cardano_builder_state_release(&state);
+
+  // Assert
+  EXPECT_EQ(state.transaction, (cardano_transaction_t*)nullptr);
+  EXPECT_EQ(state.params, (cardano_protocol_parameters_t*)nullptr);
+  EXPECT_EQ(state.coin_selector, (cardano_coin_selector_t*)nullptr);
+  EXPECT_EQ(state.tx_evaluator, (cardano_tx_evaluator_t*)nullptr);
+  EXPECT_EQ(state.change_address, (cardano_address_t*)nullptr);
+  EXPECT_EQ(state.collateral_address, (cardano_address_t*)nullptr);
+  EXPECT_EQ(state.available_utxos, (cardano_utxo_list_t*)nullptr);
+  EXPECT_EQ(state.collateral_utxos, (cardano_utxo_list_t*)nullptr);
+  EXPECT_EQ(state.pre_selected_inputs, (cardano_utxo_list_t*)nullptr);
+  EXPECT_EQ(state.reference_inputs, (cardano_utxo_list_t*)nullptr);
+  EXPECT_EQ(state.input_to_redeemer_map, (cardano_input_to_redeemer_map_t*)nullptr);
+  EXPECT_EQ(state.withdrawals_to_redeemer_map, (cardano_blake2b_hash_to_redeemer_map_t*)nullptr);
+  EXPECT_EQ(state.mints_to_redeemer_map, (cardano_blake2b_hash_to_redeemer_map_t*)nullptr);
+  EXPECT_EQ(state.votes_to_redeemer_map, (cardano_blake2b_hash_to_redeemer_map_t*)nullptr);
+  EXPECT_EQ(state.deferred_redeemers, (cardano_deferred_redeemer_list_t*)nullptr);
+
+  // Cleanup
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_release, canBeCalledMoreThanOnce)
+{
+  // Arrange
+  cardano_protocol_parameters_t* params = init_protocol_parameters();
+  cardano_builder_state_t        state  = {};
+
+  EXPECT_EQ(cardano_builder_state_init(&state, params, &CARDANO_MAINNET_SLOT_CONFIG), CARDANO_SUCCESS);
+
+  // Act
+  cardano_builder_state_release(&state);
+  cardano_builder_state_release(&state);
+
+  // Assert
+  EXPECT_EQ(state.transaction, (cardano_transaction_t*)nullptr);
+  EXPECT_EQ(cardano_protocol_parameters_refcount(params), 1U);
+
+  // Cleanup
+  cardano_protocol_parameters_unref(&params);
+}
+
+TEST(cardano_builder_state_release, doesNothingIfStateIsNull)
+{
+  // Act
+  cardano_builder_state_release(nullptr);
+}

--- a/lib/tests/transaction_builder/transaction_builder.cpp
+++ b/lib/tests/transaction_builder/transaction_builder.cpp
@@ -30,6 +30,7 @@
 #include <cardano/transaction_builder/transaction_builder.h>
 
 #include "../../src/transaction_builder/internals/blake2b_hash_to_redeemer_map.h"
+#include "../../src/transaction_builder/internals/builder_state.h"
 #include <allocators.h>
 #include <cardano/transaction_body/transaction_output.h>
 #include <cardano/transaction_builder/balancing/deferred_redeemer_list.h>
@@ -43,29 +44,9 @@
 
 typedef struct cardano_tx_builder_t
 {
-    cardano_object_t               base;
-    cardano_error_t                last_error;
-    cardano_transaction_t*         transaction;
-    cardano_protocol_parameters_t* params;
-    cardano_slot_config_t          slot_config;
-    cardano_coin_selector_t*       coin_selector;
-    cardano_tx_evaluator_t*        tx_evaluator;
-    cardano_address_t*             change_address;
-    cardano_address_t*             collateral_address;
-    cardano_utxo_list_t*           available_utxos;
-    cardano_utxo_list_t*           collateral_utxos;
-    cardano_utxo_list_t*           pre_selected_inputs;
-    cardano_utxo_list_t*           reference_inputs;
-    bool                           has_plutus_v1;
-    bool                           has_plutus_v2;
-    bool                           has_plutus_v3;
-    size_t                         additional_signature_count;
-
-    cardano_input_to_redeemer_map_t*        input_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* withdrawals_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* mints_to_redeemer_map;
-    cardano_blake2b_hash_to_redeemer_map_t* votes_to_redeemer_map;
-    cardano_deferred_redeemer_list_t*       deferred_redeemers;
+    cardano_object_t        base;
+    cardano_error_t         last_error;
+    cardano_builder_state_t state;
 } cardano_tx_builder_t;
 
 /* CONSTANTS *****************************************************************/
@@ -529,7 +510,7 @@ TEST(cardano_tx_builder_set_coin_selector, canSetCoinSelector)
   cardano_tx_builder_set_coin_selector(builder, selector);
 
   // Assert
-  EXPECT_EQ(builder->coin_selector, selector);
+  EXPECT_EQ(builder->state.coin_selector, selector);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -564,7 +545,7 @@ TEST(cardano_tx_builder_set_network_id, canSetNetworkId)
   // Act
   cardano_tx_builder_set_network_id(builder, CARDANO_NETWORK_ID_MAIN_NET);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   const cardano_network_id_t* network_id = cardano_transaction_body_get_network_id(body);
@@ -584,8 +565,8 @@ TEST(cardano_tx_builder_set_network_id, returnsErroIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_set_network_id(builder, CARDANO_NETWORK_ID_MAIN_NET);
@@ -656,7 +637,7 @@ TEST(cardano_tx_builder_set_tx_evaluator, canSetTxEvaluator)
   cardano_tx_builder_set_tx_evaluator(builder, evaluator);
 
   // Assert
-  EXPECT_EQ(builder->tx_evaluator, evaluator);
+  EXPECT_EQ(builder->state.tx_evaluator, evaluator);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -700,7 +681,7 @@ TEST(cardano_tx_builder_set_change_address, canSetChangeAddress)
   cardano_tx_builder_set_change_address(builder, address);
 
   // Assert
-  EXPECT_EQ(builder->change_address, address);
+  EXPECT_EQ(builder->state.change_address, address);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -744,7 +725,7 @@ TEST(cardano_tx_builder_set_change_address_ex, canSetChangeAddress)
   cardano_tx_builder_set_change_address_ex(builder, "addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg", strlen("addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg"));
 
   // Assert
-  EXPECT_STREQ(cardano_address_get_string(builder->change_address), cardano_address_get_string(address));
+  EXPECT_STREQ(cardano_address_get_string(builder->state.change_address), cardano_address_get_string(address));
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -811,7 +792,7 @@ TEST(cardano_tx_builder_set_collateral_change_address, canSetCollateralChangeAdd
   cardano_tx_builder_set_collateral_change_address(builder, address);
 
   // Assert
-  EXPECT_EQ(builder->collateral_address, address);
+  EXPECT_EQ(builder->state.collateral_address, address);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -855,7 +836,7 @@ TEST(cardano_tx_builder_set_collateral_change_address_ex, canSetCollateralChange
   cardano_tx_builder_set_collateral_change_address_ex(builder, "addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg", strlen("addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg"));
 
   // Assert
-  EXPECT_STREQ(cardano_address_get_string(builder->collateral_address), cardano_address_get_string(address));
+  EXPECT_STREQ(cardano_address_get_string(builder->state.collateral_address), cardano_address_get_string(address));
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -913,7 +894,7 @@ TEST(cardano_tx_builder_set_minimum_fee, canSetMinimumFee)
   // Act
   cardano_tx_builder_set_minimum_fee(builder, 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -931,8 +912,8 @@ TEST(cardano_tx_builder_set_minimum_fee, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_set_minimum_fee(builder, 1000);
@@ -971,7 +952,7 @@ TEST(cardano_tx_builder_set_donation, canSetDonationFee)
   // Act
   cardano_tx_builder_set_donation(builder, 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -992,7 +973,7 @@ TEST(cardano_tx_builder_set_donation, canUnsetDonation)
   // Act
   cardano_tx_builder_set_donation(builder, 0);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -1052,7 +1033,7 @@ TEST(cardano_tx_builder_set_utxos, canSetUtxos)
   cardano_tx_builder_set_utxos(builder, utxos);
 
   // Assert
-  EXPECT_EQ(builder->available_utxos, utxos);
+  EXPECT_EQ(builder->state.available_utxos, utxos);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -1122,7 +1103,7 @@ TEST(cardano_tx_builder_set_collateral_utxos, canSetCollateralUtxos)
   cardano_tx_builder_set_collateral_utxos(builder, utxos);
 
   // Assert
-  EXPECT_EQ(builder->collateral_utxos, utxos);
+  EXPECT_EQ(builder->state.collateral_utxos, utxos);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -1157,7 +1138,7 @@ TEST(cardano_tx_builder_set_invalid_after, canSetInvalidAfter)
   // Act
   cardano_tx_builder_set_invalid_after(builder, 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -1175,8 +1156,8 @@ TEST(cardano_tx_builder_set_invalid_after, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_set_invalid_after(builder, 1000);
@@ -1238,7 +1219,7 @@ TEST(cardano_tx_builder_set_invalid_after_ex, canSetInvalidAfter)
   // Act
   cardano_tx_builder_set_invalid_after_ex(builder, 1730901968);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -1256,8 +1237,8 @@ TEST(cardano_tx_builder_set_invalid_after_ex, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_set_invalid_after_ex(builder, 1000);
@@ -1319,7 +1300,7 @@ TEST(cardano_tx_builder_set_invalid_before, canSetInvalidBefore)
   // Act
   cardano_tx_builder_set_invalid_before(builder, 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -1337,8 +1318,8 @@ TEST(cardano_tx_builder_set_invalid_before, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_set_invalid_before(builder, 1000);
@@ -1396,7 +1377,7 @@ TEST(cardano_tx_builder_set_invalid_before_ex, canSetInvalidBefore)
 
   cardano_tx_builder_set_invalid_before_ex(builder, 1730901968);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   // Assert
@@ -1415,8 +1396,8 @@ TEST(cardano_tx_builder_set_invalid_before_ex, returnsErrorIfBodyIsNull)
   // Act
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   cardano_tx_builder_set_invalid_before_ex(builder, 1000);
 
@@ -1492,7 +1473,7 @@ TEST(cardano_tx_builder_add_reference_input, canAddReferenceInput)
   cardano_tx_builder_add_reference_input(builder, utxo3);
   cardano_tx_builder_add_reference_input(builder, utxo4);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_input_set_t* inputs = cardano_transaction_body_get_reference_inputs(body);
@@ -1520,8 +1501,8 @@ TEST(cardano_tx_builder_add_reference_input, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_add_reference_input(builder, utxo);
@@ -1546,8 +1527,8 @@ TEST(cardano_tx_builder_add_reference_input, returnsErrorIfReferenceInputsIsNull
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
   // Act
-  cardano_utxo_list_unref(&builder->reference_inputs);
-  builder->reference_inputs = NULL;
+  cardano_utxo_list_unref(&builder->state.reference_inputs);
+  builder->state.reference_inputs = NULL;
 
   cardano_tx_builder_add_reference_input(builder, utxo);
 
@@ -1622,7 +1603,7 @@ TEST(cardano_tx_builder_send_lovelace, canSendLovelace)
   // Act
   cardano_tx_builder_send_lovelace(builder, address, 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1656,8 +1637,8 @@ TEST(cardano_tx_builder_send_lovelace, returnsErrorIfBodyIsNull)
 
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   // Act
   cardano_tx_builder_send_lovelace(builder, address, 1000);
@@ -1745,7 +1726,7 @@ TEST(cardano_tx_builder_send_lovelace_ex, canSendLovelace)
 
   cardano_tx_builder_send_lovelace_ex(builder, address, strlen(address), 1000);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1843,7 +1824,7 @@ TEST(cardano_tx_builder_send_value, canSendValue)
 
   cardano_tx_builder_send_value(builder, address, value);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -1882,8 +1863,8 @@ TEST(cardano_tx_builder_send_value, returnsErrorIfBodyIsNull)
   // Act
   cardano_tx_builder_t* builder = cardano_tx_builder_new(params, &CARDANO_MAINNET_SLOT_CONFIG);
 
-  cardano_transaction_unref(&builder->transaction);
-  builder->transaction = NULL;
+  cardano_transaction_unref(&builder->state.transaction);
+  builder->state.transaction = NULL;
 
   cardano_tx_builder_send_value(builder, address, value);
 
@@ -2010,7 +1991,7 @@ TEST(cardano_tx_builder_send_value_ex, canSendValue)
 
   cardano_tx_builder_send_value_ex(builder, address, strlen(address), value);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_transaction_output_list_t* outputs = cardano_transaction_body_get_outputs(body);
@@ -2138,7 +2119,7 @@ TEST(cardano_tx_builder_pad_signer_count, canSetTheSignerCount)
   cardano_tx_builder_pad_signer_count(builder, 10);
 
   // Assert
-  EXPECT_EQ(builder->additional_signature_count, 10);
+  EXPECT_EQ(builder->state.additional_signature_count, 10);
 
   // Cleanup
   cardano_tx_builder_unref(&builder);
@@ -2408,8 +2389,8 @@ TEST(cardano_tx_builder_build, returnsErrorIfBalancingFails)
   // Act
   cardano_transaction_t* tx = nullptr;
 
-  cardano_transaction_unref(&tx_builder->transaction);
-  tx_builder->transaction = NULL;
+  cardano_transaction_unref(&tx_builder->state.transaction);
+  tx_builder->state.transaction = NULL;
 
   cardano_error_t result = cardano_tx_builder_build(tx_builder, &tx);
 
@@ -3263,10 +3244,10 @@ TEST(cardano_tx_builder_set_metadata, canSetMetadata)
   // Act
   cardano_tx_builder_set_metadata(tx_builder, 0, metadata);
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
-  cardano_auxiliary_data_t* aux_data = cardano_transaction_get_auxiliary_data(tx_builder->transaction);
+  cardano_auxiliary_data_t* aux_data = cardano_transaction_get_auxiliary_data(tx_builder->state.transaction);
   cardano_auxiliary_data_unref(&aux_data);
 
   cardano_transaction_metadata_t* tx_metadata = cardano_auxiliary_data_get_transaction_metadata(aux_data);
@@ -3359,10 +3340,10 @@ TEST(cardano_tx_builder_set_metadata_ex, canSetMetadata)
   // Act
   cardano_tx_builder_set_metadata_ex(tx_builder, 0, "{ \"name\": \"test\" }", strlen("{ \"name\": \"test\" }"));
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
-  cardano_auxiliary_data_t* aux_data = cardano_transaction_get_auxiliary_data(tx_builder->transaction);
+  cardano_auxiliary_data_t* aux_data = cardano_transaction_get_auxiliary_data(tx_builder->state.transaction);
   cardano_auxiliary_data_unref(&aux_data);
 
   cardano_transaction_metadata_t* tx_metadata = cardano_auxiliary_data_get_transaction_metadata(aux_data);
@@ -3454,7 +3435,7 @@ TEST(cardano_tx_builder_mint_token, canSentMintToken)
   cardano_tx_builder_mint_token(tx_builder, policy_id, asset_name, 4, redeemer);
   cardano_tx_builder_mint_token(tx_builder, policy_id1, asset_name, 5, NULL);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* mint = cardano_transaction_body_get_mint(body);
@@ -3559,7 +3540,7 @@ TEST(cardano_tx_builder_mint_token_ex, canSentMintToken)
   cardano_transaction_t* tx = nullptr;
   cardano_tx_builder_mint_token_ex(tx_builder, HASH_HEX, strlen(HASH_HEX), "54455854", strlen("54455854"), 4, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* mint = cardano_transaction_body_get_mint(body);
@@ -3659,7 +3640,7 @@ TEST(cardano_tx_builder_mint_token_with_id, canSentMintToken)
   cardano_transaction_t* tx = nullptr;
   cardano_tx_builder_mint_token_with_id(tx_builder, asset_id, 4, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* mint = cardano_transaction_body_get_mint(body);
@@ -3715,7 +3696,7 @@ TEST(cardano_tx_builder_mint_token_with_id_ex, canSentMintToken)
   cardano_transaction_t* tx = nullptr;
   cardano_tx_builder_mint_token_with_id_ex(tx_builder, ASSET_ID_HEX, strlen(ASSET_ID_HEX), 4, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* mint = cardano_transaction_body_get_mint(body);
@@ -3823,7 +3804,7 @@ TEST(cardano_tx_builder_add_signer, canAddSigner)
   // Act
   cardano_tx_builder_add_signer(tx_builder, signing_key);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_blake2b_hash_set_t* signers = cardano_transaction_body_get_required_signers(body);
@@ -3859,7 +3840,7 @@ TEST(cardano_tx_builder_add_signer, addingTheSameSignerTwiceKeepsASingleGuard)
   cardano_tx_builder_add_signer(tx_builder, signing_key);
   cardano_tx_builder_add_signer_ex(tx_builder, HASH_HEX, strlen(HASH_HEX));
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_guard_set_t* guards = cardano_transaction_body_get_guards(body);
@@ -3943,7 +3924,7 @@ TEST(cardano_tx_builder_add_signer_ex, canAddSigner)
   // Act
   cardano_tx_builder_add_signer_ex(tx_builder, HASH_HEX, strlen(HASH_HEX));
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_blake2b_hash_set_t* signers = cardano_transaction_body_get_required_signers(body);
@@ -4038,7 +4019,7 @@ TEST(cardano_tx_builder_add_datum, canAddDatum)
   // Act
   cardano_tx_builder_add_datum(tx_builder, datum);
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
   cardano_plutus_data_set_t* data = cardano_witness_set_get_plutus_data(witnesses);
@@ -4137,7 +4118,7 @@ TEST(cardano_tx_builder_add_script, canAddScript)
   cardano_tx_builder_add_script(tx_builder, scriptV3);
   cardano_tx_builder_add_script(tx_builder, scriptNative);
 
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
   cardano_plutus_v1_script_set_t* scripts = cardano_witness_set_get_plutus_v1_scripts(witnesses);
@@ -4157,9 +4138,9 @@ TEST(cardano_tx_builder_add_script, canAddScript)
   EXPECT_EQ(cardano_native_script_set_get_length(scriptsNative), 1);
 
   // Assert
-  EXPECT_TRUE(tx_builder->has_plutus_v1);
-  EXPECT_TRUE(tx_builder->has_plutus_v2);
-  EXPECT_TRUE(tx_builder->has_plutus_v3);
+  EXPECT_TRUE(tx_builder->state.has_plutus_v1);
+  EXPECT_TRUE(tx_builder->state.has_plutus_v2);
+  EXPECT_TRUE(tx_builder->state.has_plutus_v3);
 
   // Cleanup
   cardano_tx_builder_unref(&tx_builder);
@@ -4279,7 +4260,7 @@ TEST(cardano_tx_builder_withdraw_rewards, canWithdrawRewards)
   cardano_tx_builder_withdraw_rewards(tx_builder, script_reward, 1002, redeemer);
   cardano_tx_builder_withdraw_rewards(tx_builder, script_reward2, 1003, NULL);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_withdrawal_map_t* withdrawals = cardano_transaction_body_get_withdrawals(body);
@@ -4401,7 +4382,7 @@ TEST(cardano_tx_builder_withdraw_rewards_ex, canWithdrawRewards)
   // Act
   cardano_tx_builder_withdraw_rewards_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), 1000, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_withdrawal_map_t* withdrawals = cardano_transaction_body_get_withdrawals(body);
@@ -4468,7 +4449,7 @@ TEST(cardano_tx_builder_register_reward_address, canRegisterRewardAddress)
   // Act
   cardano_tx_builder_register_reward_address(tx_builder, reward_address, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -4554,7 +4535,7 @@ TEST(cardano_tx_builder_register_reward_address_ex, canRegisterRewardAddress)
   // Act
   cardano_tx_builder_register_reward_address_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -4609,7 +4590,7 @@ TEST(cardano_tx_builder_deregister_reward_address, canDeregisterRewardAddress)
   // Act
   cardano_tx_builder_deregister_reward_address(tx_builder, reward_address, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -4695,7 +4676,7 @@ TEST(cardano_tx_builder_deregister_reward_address_ex, canDeregisterRewardAddress
   // Act
   cardano_tx_builder_deregister_reward_address_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -4763,7 +4744,7 @@ TEST(cardano_tx_builder_delegate_stake, canDelegateStake)
   // Act
   cardano_tx_builder_delegate_stake(tx_builder, reward_address, pool_id, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -4860,7 +4841,7 @@ TEST(cardano_tx_builder_delegate_stake_ex, canDelegateStake)
   // Act
   cardano_tx_builder_delegate_stake_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), "pool1pzdqdxrv0k74p4q33y98f2u7vzaz95et7mjeedjcfy0jcgk754f", strlen("pool1pzdqdxrv0k74p4q33y98f2u7vzaz95et7mjeedjcfy0jcgk754f"), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5003,7 +4984,7 @@ TEST(cardano_tx_builder_delegate_voting_power, canDelegateVotingPower)
   // Act
   cardano_tx_builder_delegate_voting_power(tx_builder, reward_address, drep, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5132,7 +5113,7 @@ TEST(cardano_tx_builder_delegate_voting_power_ex, canDelegateVotingPower)
   // Act
   cardano_tx_builder_delegate_voting_power_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), DREP_ID, strlen(DREP_ID), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5199,7 +5180,7 @@ TEST(cardano_tx_builder_register_drep, canRegisterDrep)
   // Act
   cardano_tx_builder_register_drep(tx_builder, drep, anchor, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5310,7 +5291,7 @@ TEST(cardano_tx_builder_register_drep_ex, canRegisterDrep)
   // Act
   cardano_tx_builder_register_drep_ex(tx_builder, DREP_ID, strlen(DREP_ID), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5378,7 +5359,7 @@ TEST(cardano_tx_builder_update_drep, canUpdateDrep)
   // Act
   cardano_tx_builder_update_drep(tx_builder, drep, anchor, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5489,7 +5470,7 @@ TEST(cardano_tx_builder_update_drep_ex, canUpdateDrep)
   // Act
   cardano_tx_builder_update_drep_ex(tx_builder, DREP_ID, strlen(DREP_ID), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5552,7 +5533,7 @@ TEST(cardano_tx_builder_deregister_drep, canDeregisterDrep)
   // Act
   cardano_tx_builder_deregister_drep(tx_builder, drep, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5648,7 +5629,7 @@ TEST(cardano_tx_builder_deregister_drep_ex, canDeregisterDrep)
   // Act
   cardano_tx_builder_deregister_drep_ex(tx_builder, DREP_ID, strlen(DREP_ID), redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -5757,7 +5738,7 @@ TEST(cardano_tx_builder_vote, canVote)
   // Act
   cardano_tx_builder_vote(tx_builder, voter, action_id, procedure, redeemer);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_voting_procedures_t* procedures = cardano_transaction_body_get_voting_procedures(body);
@@ -5813,13 +5794,13 @@ TEST(cardano_tx_builder_vote, keyHashVotersOccupyARedeemerIndexSlot)
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->votes_to_redeemer_map), 2U);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->state.votes_to_redeemer_map), 2U);
 
   size_t non_null_slots = 0;
-  for (size_t i = 0; i < cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->votes_to_redeemer_map); ++i)
+  for (size_t i = 0; i < cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->state.votes_to_redeemer_map); ++i)
   {
     cardano_redeemer_t* value = nullptr;
-    EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->votes_to_redeemer_map, i, &value), CARDANO_SUCCESS);
+    EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->state.votes_to_redeemer_map, i, &value), CARDANO_SUCCESS);
 
     if (value != nullptr)
     {
@@ -5878,10 +5859,10 @@ TEST(cardano_tx_builder_vote, oneVoterVotingOnSeveralActionsUsesASingleRedeemerS
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->votes_to_redeemer_map), 1U);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->state.votes_to_redeemer_map), 1U);
 
   cardano_redeemer_t* value = nullptr;
-  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->votes_to_redeemer_map, 0, &value), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->state.votes_to_redeemer_map, 0, &value), CARDANO_SUCCESS);
   ASSERT_NE(value, (cardano_redeemer_t*)nullptr);
   EXPECT_EQ(cardano_redeemer_get_index(value), 0U);
   cardano_redeemer_unref(&value);
@@ -6053,7 +6034,7 @@ TEST(cardano_tx_builder_propose_parameter_change, canProposeParameterChange)
   // Act
   cardano_tx_builder_propose_parameter_change(tx_builder, reward_address, anchor, pparam_update, action_id, hash);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -6334,7 +6315,7 @@ TEST(cardano_tx_builder_propose_hardfork, canProposeHardfork)
   // Act
   cardano_tx_builder_propose_hardfork(tx_builder, reward_address, anchor, protocol_version, action_id);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -6600,7 +6581,7 @@ TEST(cardano_tx_builder_propose_treasury_withdrawals, canProposeTreasuryWithdraw
   // Act
   cardano_tx_builder_propose_treasury_withdrawals(tx_builder, reward_address, anchor, treasury_withdrawal, policy_id);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -6860,7 +6841,7 @@ TEST(cardano_tx_builder_propose_no_confidence, canProposeNoConfidence)
   // Act
   cardano_tx_builder_propose_no_confidence(tx_builder, reward_address, anchor, action_id);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7008,7 +6989,7 @@ TEST(cardano_tx_builder_propose_no_confidence_ex, canAddNoConfidencePorposal)
   // Act
   cardano_tx_builder_propose_no_confidence_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH), CIP129_BECH32_1, strlen(CIP129_BECH32_1));
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7191,7 +7172,7 @@ TEST(cardano_tx_builder_propose_update_committee, canProposeUpdateCommittee)
   // Act
   cardano_tx_builder_propose_update_committee(tx_builder, reward_address, anchor, action_id, members_to_be_removed, members_to_be_added, new_quorum);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7432,7 +7413,7 @@ TEST(cardano_tx_builder_propose_update_committee_ex, canProposeUpdateCommittee)
   // Act
   cardano_tx_builder_propose_update_committee_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH), CIP129_BECH32_1, strlen(CIP129_BECH32_1), members_to_be_removed, members_to_be_added, 0.0);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7606,7 +7587,7 @@ TEST(cardano_tx_builder_propose_new_constitution, canProposeNewConstitution)
   // Act
   cardano_tx_builder_propose_new_constitution(tx_builder, reward_address, anchor, action_id, constitution);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7785,7 +7766,7 @@ TEST(cardano_tx_builder_propose_new_constitution_ex, canProposeNewConstitution)
   // Act
   cardano_tx_builder_propose_new_constitution_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH), CIP129_BECH32_1, strlen(CIP129_BECH32_1), constitution);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -7908,7 +7889,7 @@ TEST(cardano_tx_builder_propose_info, canProposeInfo)
   // Act
   cardano_tx_builder_propose_info(tx_builder, reward_address, anchor);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -8031,7 +8012,7 @@ TEST(cardano_tx_builder_propose_info_ex, canProposeInfo)
   // Act
   cardano_tx_builder_propose_info_ex(tx_builder, REWARD_ADDRESS, strlen(REWARD_ADDRESS), ANCHOR_URL, strlen(ANCHOR_URL), ANCHOR_HASH, strlen(ANCHOR_HASH));
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_proposal_procedure_set_t* actions = cardano_transaction_body_get_proposal_procedures(body);
@@ -8593,9 +8574,9 @@ TEST(cardano_tx_builder_mint_token_with_deferred_redeemer, registersDeferredRede
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 1U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 1U);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_multi_asset_t* mint = cardano_transaction_body_get_mint(body);
@@ -8607,7 +8588,7 @@ TEST(cardano_tx_builder_mint_token_with_deferred_redeemer, registersDeferredRede
 
   // The mint redeemer starts out as the placeholder `constr 0 []`...
   cardano_redeemer_t* redeemer = NULL;
-  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get(tx_builder->mints_to_redeemer_map, policy_id, &redeemer), CARDANO_SUCCESS);
+  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get(tx_builder->state.mints_to_redeemer_map, policy_id, &redeemer), CARDANO_SUCCESS);
   cardano_redeemer_unref(&redeemer);
 
   cardano_plutus_data_t* placeholder = new_placeholder_plutus_data();
@@ -8620,7 +8601,7 @@ TEST(cardano_tx_builder_mint_token_with_deferred_redeemer, registersDeferredRede
   cardano_utxo_list_t* resolved_inputs = NULL;
   EXPECT_EQ(cardano_utxo_list_new(&resolved_inputs), CARDANO_SUCCESS);
 
-  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->deferred_redeemers, tx_builder->transaction, resolved_inputs), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->state.deferred_redeemers, tx_builder->state.transaction, resolved_inputs), CARDANO_SUCCESS);
 
   cardano_plutus_data_t* expected = NULL;
   EXPECT_EQ(cardano_plutus_data_new_integer_from_int(7, &expected), CARDANO_SUCCESS);
@@ -8670,7 +8651,7 @@ TEST(cardano_tx_builder_mint_token_with_deferred_redeemer, latchesErrorOnNullArg
   tx_builder->last_error = CARDANO_ERROR_GENERIC;
   cardano_tx_builder_mint_token_with_deferred_redeemer(tx_builder, policy_id, asset_name, 4, fixed_payload_deferred_callback, NULL);
   EXPECT_EQ(tx_builder->last_error, CARDANO_ERROR_GENERIC);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 0U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 0U);
 
   // Cleanup
   cardano_tx_builder_unref(&tx_builder);
@@ -8744,12 +8725,12 @@ TEST(cardano_tx_builder_withdraw_rewards_with_deferred_redeemer, registersDeferr
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 1U);
-  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->withdrawals_to_redeemer_map), 1U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 1U);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->state.withdrawals_to_redeemer_map), 1U);
 
   // The withdrawal redeemer starts out as the placeholder `constr 0 []`...
   cardano_redeemer_t* redeemer = NULL;
-  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->withdrawals_to_redeemer_map, 0U, &redeemer), CARDANO_SUCCESS);
+  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->state.withdrawals_to_redeemer_map, 0U, &redeemer), CARDANO_SUCCESS);
   cardano_redeemer_unref(&redeemer);
 
   cardano_plutus_data_t* placeholder = new_placeholder_plutus_data();
@@ -8762,7 +8743,7 @@ TEST(cardano_tx_builder_withdraw_rewards_with_deferred_redeemer, registersDeferr
   cardano_utxo_list_t* resolved_inputs = NULL;
   EXPECT_EQ(cardano_utxo_list_new(&resolved_inputs), CARDANO_SUCCESS);
 
-  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->deferred_redeemers, tx_builder->transaction, resolved_inputs), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->state.deferred_redeemers, tx_builder->state.transaction, resolved_inputs), CARDANO_SUCCESS);
 
   cardano_plutus_data_t* expected = NULL;
   EXPECT_EQ(cardano_plutus_data_new_integer_from_int(7, &expected), CARDANO_SUCCESS);
@@ -8808,7 +8789,7 @@ TEST(cardano_tx_builder_withdraw_rewards_with_deferred_redeemer, latchesErrorOnN
   // A failure in the underlying withdrawal declaration must abort the registration.
   cardano_tx_builder_withdraw_rewards_with_deferred_redeemer(tx_builder, reward_address, -1, fixed_payload_deferred_callback, NULL);
   EXPECT_EQ(tx_builder->last_error, CARDANO_ERROR_INVALID_ARGUMENT);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 0U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 0U);
 
   // Cleanup
   cardano_tx_builder_unref(&tx_builder);
@@ -8895,9 +8876,9 @@ TEST(cardano_tx_builder_add_certificate_with_deferred_redeemer, registersDeferre
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 1U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 1U);
 
-  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->transaction);
+  cardano_transaction_body_t* body = cardano_transaction_get_body(tx_builder->state.transaction);
   cardano_transaction_body_unref(&body);
 
   cardano_certificate_set_t* certs = cardano_transaction_body_get_certificates(body);
@@ -8906,7 +8887,7 @@ TEST(cardano_tx_builder_add_certificate_with_deferred_redeemer, registersDeferre
   EXPECT_EQ(cardano_certificate_set_get_length(certs), 1U);
 
   // The certificate redeemer starts out as the placeholder `constr 0 []`...
-  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->transaction);
+  cardano_witness_set_t* witnesses = cardano_transaction_get_witness_set(tx_builder->state.transaction);
   cardano_witness_set_unref(&witnesses);
 
   cardano_redeemer_list_t* redeemers = cardano_witness_set_get_redeemers(witnesses);
@@ -8931,7 +8912,7 @@ TEST(cardano_tx_builder_add_certificate_with_deferred_redeemer, registersDeferre
   cardano_utxo_list_t* resolved_inputs = NULL;
   EXPECT_EQ(cardano_utxo_list_new(&resolved_inputs), CARDANO_SUCCESS);
 
-  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->deferred_redeemers, tx_builder->transaction, resolved_inputs), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->state.deferred_redeemers, tx_builder->state.transaction, resolved_inputs), CARDANO_SUCCESS);
 
   cardano_plutus_data_t* expected = NULL;
   EXPECT_EQ(cardano_plutus_data_new_integer_from_int(7, &expected), CARDANO_SUCCESS);
@@ -8976,7 +8957,7 @@ TEST(cardano_tx_builder_add_certificate_with_deferred_redeemer, latchesErrorOnNu
   tx_builder->last_error = CARDANO_ERROR_GENERIC;
   cardano_tx_builder_add_certificate_with_deferred_redeemer(tx_builder, certificate, fixed_payload_deferred_callback, NULL);
   EXPECT_EQ(tx_builder->last_error, CARDANO_ERROR_GENERIC);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 0U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 0U);
 
   // Cleanup
   cardano_tx_builder_unref(&tx_builder);
@@ -9047,12 +9028,12 @@ TEST(cardano_tx_builder_vote_with_deferred_redeemer, registersDeferredRedeemerFo
 
   // Assert
   EXPECT_EQ(tx_builder->last_error, CARDANO_SUCCESS);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 1U);
-  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->votes_to_redeemer_map), 1U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 1U);
+  EXPECT_EQ(cardano_blake2b_hash_to_redeemer_map_get_length(tx_builder->state.votes_to_redeemer_map), 1U);
 
   // The vote redeemer starts out as the placeholder `constr 0 []`...
   cardano_redeemer_t* redeemer = NULL;
-  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->votes_to_redeemer_map, 0U, &redeemer), CARDANO_SUCCESS);
+  ASSERT_EQ(cardano_blake2b_hash_to_redeemer_map_get_value_at(tx_builder->state.votes_to_redeemer_map, 0U, &redeemer), CARDANO_SUCCESS);
   cardano_redeemer_unref(&redeemer);
 
   EXPECT_EQ(cardano_redeemer_get_tag(redeemer), CARDANO_REDEEMER_TAG_VOTING);
@@ -9067,7 +9048,7 @@ TEST(cardano_tx_builder_vote_with_deferred_redeemer, registersDeferredRedeemerFo
   cardano_utxo_list_t* resolved_inputs = NULL;
   EXPECT_EQ(cardano_utxo_list_new(&resolved_inputs), CARDANO_SUCCESS);
 
-  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->deferred_redeemers, tx_builder->transaction, resolved_inputs), CARDANO_SUCCESS);
+  EXPECT_EQ(cardano_deferred_redeemer_list_resolve(tx_builder->state.deferred_redeemers, tx_builder->state.transaction, resolved_inputs), CARDANO_SUCCESS);
 
   cardano_plutus_data_t* expected = NULL;
   EXPECT_EQ(cardano_plutus_data_new_integer_from_int(7, &expected), CARDANO_SUCCESS);
@@ -9132,7 +9113,7 @@ TEST(cardano_tx_builder_vote_with_deferred_redeemer, latchesErrorOnNullArguments
   tx_builder->last_error = CARDANO_ERROR_GENERIC;
   cardano_tx_builder_vote_with_deferred_redeemer(tx_builder, voter, action_id, procedure, fixed_payload_deferred_callback, NULL);
   EXPECT_EQ(tx_builder->last_error, CARDANO_ERROR_GENERIC);
-  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->deferred_redeemers), 0U);
+  EXPECT_EQ(cardano_deferred_redeemer_list_get_length(tx_builder->state.deferred_redeemers), 0U);
 
   // Cleanup
   cardano_tx_builder_unref(&tx_builder);


### PR DESCRIPTION
Phase 2 of #133: the transaction builder core extraction. Pure refactor, zero behavior change, groundwork for the sub transaction builder.

`transaction_builder.c` went from 5,435 lines of monolithic function bodies to a 1,675 line facade (lifecycle + 81 thin wrappers) over 12 composable modules under `transaction_builder/internals/` (same pattern the balancing and coin selection internals already use): `builder_state` (the shared state struct the future `cardano_sub_tx_builder_t` will compose), inputs, outputs, mint, the shared redeemer helpers, certs, withdrawals, proposals, votes, config, witnesses and the build orchestration.

The refactor discipline was strict: bodies moved verbatim with mechanical adaptations only (state parameter, the deferred error model routed through a single `track_builder_result`), pre-existing quirks preserved on purpose and logged for separate follow ups instead of fixed in place (a couple of theoretical leaks on unreachable error paths, an index underflow on a set-add failure path, dead stores, they are all in the tracking notes). Every slice was reviewed against the deleted code line by line before landing.

Guarantees, verified per slice and again end to end:
- The public header is byte identical (`sha256` pinned) and the exported `cardano_tx_builder_*` symbol surface is identical to main (81 symbols both sides).
- The full suite (10,977 tests) is green with existing tests unmodified except the white box test mirror, which now points at the real state struct instead of a hand copied layout (that copy was a latent landmine, it only worked by offset coincidence).
- cppcheck, clang-tidy, the MISRA gate (0 violations, no new suppressions) and the chunked valgrind run are all clean.

Every enum and struct sits in its own header per the house one-type-per-file style, docs are behavior-only on every internal symbol, no inline comments.

Next per the ticket: phases 3+ (the sub transaction builder and batch balancing) stay gated on the upstream CIP-118 ledger rules settling, see the watch list in #133.
