### PR TITLE
refactor: share the body field codecs between the transaction bodies

### DIFF
--- a/lib/src/transaction_body/internals/body_fields.c
+++ b/lib/src/transaction_body/internals/body_fields.c
@@ -1,0 +1,674 @@
+/**
+ * \file body_fields.c
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "body_fields.h"
+
+#include <assert.h>
+
+/* IMPLEMENTATION ************************************************************/
+
+cardano_error_t
+cardano_body_read_inputs(cardano_cbor_reader_t* reader, cardano_transaction_input_set_t** inputs)
+{
+  assert(reader != NULL);
+  assert(inputs != NULL);
+
+  return cardano_transaction_input_set_from_cbor(reader, inputs);
+}
+
+cardano_error_t
+cardano_body_read_outputs(cardano_cbor_reader_t* reader, cardano_transaction_output_list_t** outputs)
+{
+  assert(reader != NULL);
+  assert(outputs != NULL);
+
+  return cardano_transaction_output_list_from_cbor(reader, outputs);
+}
+
+cardano_error_t
+cardano_body_read_ttl(cardano_cbor_reader_t* reader, uint64_t* ttl)
+{
+  assert(reader != NULL);
+  assert(ttl != NULL);
+
+  return cardano_cbor_reader_read_uint(reader, ttl);
+}
+
+cardano_error_t
+cardano_body_read_certificates(cardano_cbor_reader_t* reader, cardano_certificate_set_t** certificates)
+{
+  assert(reader != NULL);
+  assert(certificates != NULL);
+
+  return cardano_certificate_set_from_cbor(reader, certificates);
+}
+
+cardano_error_t
+cardano_body_read_withdrawals(cardano_cbor_reader_t* reader, cardano_withdrawal_map_t** withdrawals)
+{
+  assert(reader != NULL);
+  assert(withdrawals != NULL);
+
+  return cardano_withdrawal_map_from_cbor(reader, withdrawals);
+}
+
+cardano_error_t
+cardano_body_read_aux_data_hash(cardano_cbor_reader_t* reader, cardano_blake2b_hash_t** aux_data_hash)
+{
+  assert(reader != NULL);
+  assert(aux_data_hash != NULL);
+
+  return cardano_blake2b_hash_from_cbor(reader, aux_data_hash);
+}
+
+cardano_error_t
+cardano_body_read_validity_start(cardano_cbor_reader_t* reader, uint64_t* validity_start)
+{
+  assert(reader != NULL);
+  assert(validity_start != NULL);
+
+  return cardano_cbor_reader_read_uint(reader, validity_start);
+}
+
+cardano_error_t
+cardano_body_read_mint(cardano_cbor_reader_t* reader, cardano_multi_asset_t** mint)
+{
+  assert(reader != NULL);
+  assert(mint != NULL);
+
+  return cardano_multi_asset_from_cbor(reader, mint);
+}
+
+cardano_error_t
+cardano_body_read_script_data_hash(cardano_cbor_reader_t* reader, cardano_blake2b_hash_t** script_data_hash)
+{
+  assert(reader != NULL);
+  assert(script_data_hash != NULL);
+
+  return cardano_blake2b_hash_from_cbor(reader, script_data_hash);
+}
+
+cardano_error_t
+cardano_body_read_guards(cardano_cbor_reader_t* reader, cardano_guard_set_t** guards)
+{
+  assert(reader != NULL);
+  assert(guards != NULL);
+
+  return cardano_guard_set_from_cbor(reader, guards);
+}
+
+cardano_error_t
+cardano_body_read_network_id(cardano_cbor_reader_t* reader, cardano_network_id_t* network_id)
+{
+  assert(reader != NULL);
+  assert(network_id != NULL);
+
+  return cardano_cbor_reader_read_uint(reader, (uint64_t*)((void*)network_id));
+}
+
+cardano_error_t
+cardano_body_read_reference_inputs(cardano_cbor_reader_t* reader, cardano_transaction_input_set_t** reference_inputs)
+{
+  assert(reader != NULL);
+  assert(reference_inputs != NULL);
+
+  return cardano_transaction_input_set_from_cbor(reader, reference_inputs);
+}
+
+cardano_error_t
+cardano_body_read_voting_procedures(cardano_cbor_reader_t* reader, cardano_voting_procedures_t** voting_procedures)
+{
+  assert(reader != NULL);
+  assert(voting_procedures != NULL);
+
+  return cardano_voting_procedures_from_cbor(reader, voting_procedures);
+}
+
+cardano_error_t
+cardano_body_read_proposal_procedures(cardano_cbor_reader_t* reader, cardano_proposal_procedure_set_t** proposal_procedures)
+{
+  assert(reader != NULL);
+  assert(proposal_procedures != NULL);
+
+  return cardano_proposal_procedure_set_from_cbor(reader, proposal_procedures);
+}
+
+cardano_error_t
+cardano_body_read_treasury_value(cardano_cbor_reader_t* reader, uint64_t* treasury_value)
+{
+  assert(reader != NULL);
+  assert(treasury_value != NULL);
+
+  return cardano_cbor_reader_read_uint(reader, treasury_value);
+}
+
+cardano_error_t
+cardano_body_read_donation(cardano_cbor_reader_t* reader, uint64_t* donation)
+{
+  assert(reader != NULL);
+  assert(donation != NULL);
+
+  return cardano_cbor_reader_read_uint(reader, donation);
+}
+
+cardano_error_t
+cardano_body_read_required_top_level_guards(cardano_cbor_reader_t* reader, cardano_required_guards_map_t** required_top_level_guards)
+{
+  assert(reader != NULL);
+  assert(required_top_level_guards != NULL);
+
+  return cardano_required_guards_map_from_cbor(reader, required_top_level_guards);
+}
+
+cardano_error_t
+cardano_body_read_direct_deposits(cardano_cbor_reader_t* reader, cardano_direct_deposit_map_t** direct_deposits)
+{
+  assert(reader != NULL);
+  assert(direct_deposits != NULL);
+
+  return cardano_direct_deposit_map_from_cbor(reader, direct_deposits);
+}
+
+cardano_error_t
+cardano_body_read_account_balance_intervals(cardano_cbor_reader_t* reader, cardano_account_balance_intervals_map_t** account_balance_intervals)
+{
+  assert(reader != NULL);
+  assert(account_balance_intervals != NULL);
+
+  return cardano_account_balance_intervals_map_from_cbor(reader, account_balance_intervals);
+}
+
+cardano_error_t
+cardano_body_write_inputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_input_set_t* inputs)
+{
+  assert(writer != NULL);
+
+  if (inputs != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 0U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_transaction_input_set_to_cbor(inputs, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_outputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_output_list_t* outputs)
+{
+  assert(writer != NULL);
+
+  if (outputs != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 1U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_transaction_output_list_to_cbor(outputs, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_ttl_if_present(cardano_cbor_writer_t* writer, const uint64_t* ttl)
+{
+  assert(writer != NULL);
+
+  if (ttl != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 3U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_cbor_writer_write_uint(writer, *ttl);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_certificates_if_present(cardano_cbor_writer_t* writer, const cardano_certificate_set_t* certificates)
+{
+  assert(writer != NULL);
+
+  if (certificates != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 4U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_certificate_set_to_cbor(certificates, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_withdrawals_if_present(cardano_cbor_writer_t* writer, const cardano_withdrawal_map_t* withdrawals)
+{
+  assert(writer != NULL);
+
+  if (withdrawals != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 5U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_withdrawal_map_to_cbor(withdrawals, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_aux_data_hash_if_present(cardano_cbor_writer_t* writer, const cardano_blake2b_hash_t* aux_data_hash)
+{
+  assert(writer != NULL);
+
+  if (aux_data_hash != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 7U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_blake2b_hash_to_cbor(aux_data_hash, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_validity_start_if_present(cardano_cbor_writer_t* writer, const uint64_t* validity_start)
+{
+  assert(writer != NULL);
+
+  if (validity_start != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 8U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_cbor_writer_write_uint(writer, *validity_start);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_mint_if_present(cardano_cbor_writer_t* writer, const cardano_multi_asset_t* mint)
+{
+  assert(writer != NULL);
+
+  if (mint != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 9U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_multi_asset_to_cbor(mint, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_script_data_hash_if_present(cardano_cbor_writer_t* writer, const cardano_blake2b_hash_t* script_data_hash)
+{
+  assert(writer != NULL);
+
+  if (script_data_hash != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 11U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_blake2b_hash_to_cbor(script_data_hash, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_guards_if_present(cardano_cbor_writer_t* writer, const cardano_guard_set_t* guards)
+{
+  assert(writer != NULL);
+
+  if (guards != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 14U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_guard_set_to_cbor(guards, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_network_id_if_present(cardano_cbor_writer_t* writer, const cardano_network_id_t* network_id)
+{
+  assert(writer != NULL);
+
+  if (network_id != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 15U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_cbor_writer_write_uint(writer, *network_id);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_reference_inputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_input_set_t* reference_inputs)
+{
+  assert(writer != NULL);
+
+  if (reference_inputs != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 18U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_transaction_input_set_to_cbor(reference_inputs, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_voting_procedures_if_present(cardano_cbor_writer_t* writer, const cardano_voting_procedures_t* voting_procedures)
+{
+  assert(writer != NULL);
+
+  if (voting_procedures != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 19U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_voting_procedures_to_cbor(voting_procedures, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_proposal_procedures_if_present(cardano_cbor_writer_t* writer, const cardano_proposal_procedure_set_t* proposal_procedures)
+{
+  assert(writer != NULL);
+
+  if (proposal_procedures != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 20U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_proposal_procedure_set_to_cbor(proposal_procedures, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_treasury_value_if_present(cardano_cbor_writer_t* writer, const uint64_t* treasury_value)
+{
+  assert(writer != NULL);
+
+  if (treasury_value != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 21U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_cbor_writer_write_uint(writer, *treasury_value);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_donation_if_present(cardano_cbor_writer_t* writer, const uint64_t* donation)
+{
+  assert(writer != NULL);
+
+  if (donation != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 22U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_cbor_writer_write_uint(writer, *donation);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_required_top_level_guards_if_present(cardano_cbor_writer_t* writer, const cardano_required_guards_map_t* required_top_level_guards)
+{
+  assert(writer != NULL);
+
+  if (required_top_level_guards != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 24U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_required_guards_map_to_cbor(required_top_level_guards, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_direct_deposits_if_present(cardano_cbor_writer_t* writer, const cardano_direct_deposit_map_t* direct_deposits)
+{
+  assert(writer != NULL);
+
+  if (direct_deposits != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 25U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_direct_deposit_map_to_cbor(direct_deposits, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}
+
+cardano_error_t
+cardano_body_write_account_balance_intervals_if_present(cardano_cbor_writer_t* writer, const cardano_account_balance_intervals_map_t* account_balance_intervals)
+{
+  assert(writer != NULL);
+
+  if (account_balance_intervals != NULL)
+  {
+    cardano_error_t result = cardano_cbor_writer_write_uint(writer, 26U);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+
+    result = cardano_account_balance_intervals_map_to_cbor(account_balance_intervals, writer);
+
+    if (result != CARDANO_SUCCESS)
+    {
+      return result;
+    }
+  }
+
+  return CARDANO_SUCCESS;
+}

--- a/lib/src/transaction_body/internals/body_fields.h
+++ b/lib/src/transaction_body/internals/body_fields.h
@@ -1,0 +1,683 @@
+/**
+ * \file body_fields.h
+ *
+ * \author angel.castillo
+ * \date   Jul 18, 2026
+ *
+ * Copyright 2026 Biglup Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BIGLUP_LABS_INCLUDE_CARDANO_BODY_FIELDS_H
+#define BIGLUP_LABS_INCLUDE_CARDANO_BODY_FIELDS_H
+
+/* INCLUDES ******************************************************************/
+
+#include <cardano/assets/multi_asset.h>
+#include <cardano/cbor/cbor_reader.h>
+#include <cardano/cbor/cbor_writer.h>
+#include <cardano/certs/certificate_set.h>
+#include <cardano/common/guard_set.h>
+#include <cardano/common/network_id.h>
+#include <cardano/common/withdrawal_map.h>
+#include <cardano/crypto/blake2b_hash.h>
+#include <cardano/error.h>
+#include <cardano/proposal_procedures/proposal_procedure_set.h>
+#include <cardano/transaction_body/account_balance_intervals_map.h>
+#include <cardano/transaction_body/direct_deposit_map.h>
+#include <cardano/transaction_body/required_guards_map.h>
+#include <cardano/transaction_body/transaction_input_set.h>
+#include <cardano/transaction_body/transaction_output_list.h>
+#include <cardano/voting_procedures/voting_procedures.h>
+
+/* DECLARATIONS **************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Reads the wire form of a body inputs field value.
+ *
+ * This function decodes a transaction input set from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] inputs On success, points to the decoded transaction input set. The caller owns
+ *                    the returned reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_inputs(cardano_cbor_reader_t* reader, cardano_transaction_input_set_t** inputs);
+
+/**
+ * \brief Reads the wire form of a body outputs field value.
+ *
+ * This function decodes a transaction output list from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] outputs On success, points to the decoded transaction output list. The caller owns
+ *                     the returned reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_outputs(cardano_cbor_reader_t* reader, cardano_transaction_output_list_t** outputs);
+
+/**
+ * \brief Reads the wire form of a body time to live field value.
+ *
+ * This function decodes an unsigned integer from the given CBOR reader and stores it in \p ttl.
+ * The map key is expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] ttl A pointer to the storage that receives the decoded value. This parameter must
+ *                 not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_ttl(cardano_cbor_reader_t* reader, uint64_t* ttl);
+
+/**
+ * \brief Reads the wire form of a body certificates field value.
+ *
+ * This function decodes a certificate set from the given CBOR reader. The map key is expected
+ * to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] certificates On success, points to the decoded certificate set. The caller owns
+ *                          the returned reference and must release it. This parameter must not
+ *                          be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_certificates(cardano_cbor_reader_t* reader, cardano_certificate_set_t** certificates);
+
+/**
+ * \brief Reads the wire form of a body withdrawals field value.
+ *
+ * This function decodes a withdrawal map from the given CBOR reader. The map key is expected
+ * to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] withdrawals On success, points to the decoded withdrawal map. The caller owns the
+ *                         returned reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_withdrawals(cardano_cbor_reader_t* reader, cardano_withdrawal_map_t** withdrawals);
+
+/**
+ * \brief Reads the wire form of a body auxiliary data hash field value.
+ *
+ * This function decodes a blake2b hash from the given CBOR reader. The map key is expected to
+ * have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] aux_data_hash On success, points to the decoded hash. The caller owns the returned
+ *                           reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_aux_data_hash(cardano_cbor_reader_t* reader, cardano_blake2b_hash_t** aux_data_hash);
+
+/**
+ * \brief Reads the wire form of a body validity start interval field value.
+ *
+ * This function decodes an unsigned integer from the given CBOR reader and stores it in
+ * \p validity_start. The map key is expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] validity_start A pointer to the storage that receives the decoded value. This
+ *                            parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_validity_start(cardano_cbor_reader_t* reader, uint64_t* validity_start);
+
+/**
+ * \brief Reads the wire form of a body mint field value.
+ *
+ * This function decodes a multi asset from the given CBOR reader. The map key is expected to
+ * have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] mint On success, points to the decoded multi asset. The caller owns the returned
+ *                  reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_mint(cardano_cbor_reader_t* reader, cardano_multi_asset_t** mint);
+
+/**
+ * \brief Reads the wire form of a body script data hash field value.
+ *
+ * This function decodes a blake2b hash from the given CBOR reader. The map key is expected to
+ * have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] script_data_hash On success, points to the decoded hash. The caller owns the
+ *                              returned reference and must release it. This parameter must not
+ *                              be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_script_data_hash(cardano_cbor_reader_t* reader, cardano_blake2b_hash_t** script_data_hash);
+
+/**
+ * \brief Reads the wire form of a body guards field value.
+ *
+ * This function decodes a guard set from the given CBOR reader. The map key is expected to have
+ * already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] guards On success, points to the decoded guard set. The caller owns the returned
+ *                    reference and must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_guards(cardano_cbor_reader_t* reader, cardano_guard_set_t** guards);
+
+/**
+ * \brief Reads the wire form of a body network id field value.
+ *
+ * This function decodes an unsigned integer from the given CBOR reader and stores it in the
+ * storage pointed to by \p network_id. The map key is expected to have already been consumed by
+ * the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] network_id A pointer to the storage that receives the decoded value. The storage
+ *                        must be at least the size of an unsigned 64 bit integer. This parameter
+ *                        must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_network_id(cardano_cbor_reader_t* reader, cardano_network_id_t* network_id);
+
+/**
+ * \brief Reads the wire form of a body reference inputs field value.
+ *
+ * This function decodes a transaction input set from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] reference_inputs On success, points to the decoded transaction input set. The
+ *                              caller owns the returned reference and must release it. This
+ *                              parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_reference_inputs(cardano_cbor_reader_t* reader, cardano_transaction_input_set_t** reference_inputs);
+
+/**
+ * \brief Reads the wire form of a body voting procedures field value.
+ *
+ * This function decodes a voting procedures object from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] voting_procedures On success, points to the decoded voting procedures. The caller
+ *                               owns the returned reference and must release it. This parameter
+ *                               must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_voting_procedures(cardano_cbor_reader_t* reader, cardano_voting_procedures_t** voting_procedures);
+
+/**
+ * \brief Reads the wire form of a body proposal procedures field value.
+ *
+ * This function decodes a proposal procedure set from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] proposal_procedures On success, points to the decoded proposal procedure set. The
+ *                                 caller owns the returned reference and must release it. This
+ *                                 parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_proposal_procedures(cardano_cbor_reader_t* reader, cardano_proposal_procedure_set_t** proposal_procedures);
+
+/**
+ * \brief Reads the wire form of a body treasury value field value.
+ *
+ * This function decodes an unsigned integer from the given CBOR reader and stores it in
+ * \p treasury_value. The map key is expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] treasury_value A pointer to the storage that receives the decoded value. This
+ *                            parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_treasury_value(cardano_cbor_reader_t* reader, uint64_t* treasury_value);
+
+/**
+ * \brief Reads the wire form of a body donation field value.
+ *
+ * This function decodes an unsigned integer from the given CBOR reader and stores it in
+ * \p donation. The map key is expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] donation A pointer to the storage that receives the decoded value. This parameter
+ *                      must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_donation(cardano_cbor_reader_t* reader, uint64_t* donation);
+
+/**
+ * \brief Reads the wire form of a body required top level guards field value.
+ *
+ * This function decodes a required guards map from the given CBOR reader. The map key is
+ * expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] required_top_level_guards On success, points to the decoded required guards map.
+ *                                       The caller owns the returned reference and must release
+ *                                       it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_required_top_level_guards(cardano_cbor_reader_t* reader, cardano_required_guards_map_t** required_top_level_guards);
+
+/**
+ * \brief Reads the wire form of a body direct deposits field value.
+ *
+ * This function decodes a direct deposit map from the given CBOR reader. The map key is expected
+ * to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] direct_deposits On success, points to the decoded direct deposit map. The caller
+ *                             owns the returned reference and must release it. This parameter
+ *                             must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_direct_deposits(cardano_cbor_reader_t* reader, cardano_direct_deposit_map_t** direct_deposits);
+
+/**
+ * \brief Reads the wire form of a body account balance intervals field value.
+ *
+ * This function decodes an account balance intervals map from the given CBOR reader. The map key
+ * is expected to have already been consumed by the caller.
+ *
+ * \param[in] reader A pointer to the CBOR reader positioned at the field value. This parameter
+ *                   must not be NULL.
+ * \param[out] account_balance_intervals On success, points to the decoded account balance
+ *                                       intervals map. The caller owns the returned reference and
+ *                                       must release it. This parameter must not be NULL.
+ *
+ * \return \ref CARDANO_SUCCESS if the value was decoded, or an appropriate error code indicating
+ *         the failure reason.
+ */
+cardano_error_t
+cardano_body_read_account_balance_intervals(cardano_cbor_reader_t* reader, cardano_account_balance_intervals_map_t** account_balance_intervals);
+
+/**
+ * \brief Writes a body inputs field as a key value pair when the value is present.
+ *
+ * This function writes map key 0 followed by the CBOR encoding of \p inputs to the given writer.
+ * If \p inputs is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] inputs A pointer to the transaction input set to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_inputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_input_set_t* inputs);
+
+/**
+ * \brief Writes a body outputs field as a key value pair when the value is present.
+ *
+ * This function writes map key 1 followed by the CBOR encoding of \p outputs to the given writer.
+ * If \p outputs is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] outputs A pointer to the transaction output list to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_outputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_output_list_t* outputs);
+
+/**
+ * \brief Writes a body time to live field as a key value pair when the value is present.
+ *
+ * This function writes map key 3 followed by the CBOR encoding of \p ttl to the given writer.
+ * If \p ttl is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] ttl A pointer to the unsigned integer value to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_ttl_if_present(cardano_cbor_writer_t* writer, const uint64_t* ttl);
+
+/**
+ * \brief Writes a body certificates field as a key value pair when the value is present.
+ *
+ * This function writes map key 4 followed by the CBOR encoding of \p certificates to the given
+ * writer. If \p certificates is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] certificates A pointer to the certificate set to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_certificates_if_present(cardano_cbor_writer_t* writer, const cardano_certificate_set_t* certificates);
+
+/**
+ * \brief Writes a body withdrawals field as a key value pair when the value is present.
+ *
+ * This function writes map key 5 followed by the CBOR encoding of \p withdrawals to the given
+ * writer. If \p withdrawals is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] withdrawals A pointer to the withdrawal map to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_withdrawals_if_present(cardano_cbor_writer_t* writer, const cardano_withdrawal_map_t* withdrawals);
+
+/**
+ * \brief Writes a body auxiliary data hash field as a key value pair when the value is present.
+ *
+ * This function writes map key 7 followed by the CBOR encoding of \p aux_data_hash to the given
+ * writer. If \p aux_data_hash is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] aux_data_hash A pointer to the blake2b hash to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_aux_data_hash_if_present(cardano_cbor_writer_t* writer, const cardano_blake2b_hash_t* aux_data_hash);
+
+/**
+ * \brief Writes a body validity start interval field as a key value pair when the value is present.
+ *
+ * This function writes map key 8 followed by the CBOR encoding of \p validity_start to the given
+ * writer. If \p validity_start is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] validity_start A pointer to the unsigned integer value to write. If NULL, nothing is
+ *                           written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_validity_start_if_present(cardano_cbor_writer_t* writer, const uint64_t* validity_start);
+
+/**
+ * \brief Writes a body mint field as a key value pair when the value is present.
+ *
+ * This function writes map key 9 followed by the CBOR encoding of \p mint to the given writer.
+ * If \p mint is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] mint A pointer to the multi asset to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_mint_if_present(cardano_cbor_writer_t* writer, const cardano_multi_asset_t* mint);
+
+/**
+ * \brief Writes a body script data hash field as a key value pair when the value is present.
+ *
+ * This function writes map key 11 followed by the CBOR encoding of \p script_data_hash to the
+ * given writer. If \p script_data_hash is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] script_data_hash A pointer to the blake2b hash to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_script_data_hash_if_present(cardano_cbor_writer_t* writer, const cardano_blake2b_hash_t* script_data_hash);
+
+/**
+ * \brief Writes a body guards field as a key value pair when the value is present.
+ *
+ * This function writes map key 14 followed by the CBOR encoding of \p guards to the given writer.
+ * If \p guards is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] guards A pointer to the guard set to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_guards_if_present(cardano_cbor_writer_t* writer, const cardano_guard_set_t* guards);
+
+/**
+ * \brief Writes a body network id field as a key value pair when the value is present.
+ *
+ * This function writes map key 15 followed by the CBOR encoding of \p network_id to the given
+ * writer. If \p network_id is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] network_id A pointer to the network id value to write. If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_network_id_if_present(cardano_cbor_writer_t* writer, const cardano_network_id_t* network_id);
+
+/**
+ * \brief Writes a body reference inputs field as a key value pair when the value is present.
+ *
+ * This function writes map key 18 followed by the CBOR encoding of \p reference_inputs to the
+ * given writer. If \p reference_inputs is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] reference_inputs A pointer to the transaction input set to write. If NULL, nothing
+ *                             is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_reference_inputs_if_present(cardano_cbor_writer_t* writer, const cardano_transaction_input_set_t* reference_inputs);
+
+/**
+ * \brief Writes a body voting procedures field as a key value pair when the value is present.
+ *
+ * This function writes map key 19 followed by the CBOR encoding of \p voting_procedures to the
+ * given writer. If \p voting_procedures is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] voting_procedures A pointer to the voting procedures to write. If NULL, nothing is
+ *                              written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_voting_procedures_if_present(cardano_cbor_writer_t* writer, const cardano_voting_procedures_t* voting_procedures);
+
+/**
+ * \brief Writes a body proposal procedures field as a key value pair when the value is present.
+ *
+ * This function writes map key 20 followed by the CBOR encoding of \p proposal_procedures to the
+ * given writer. If \p proposal_procedures is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] proposal_procedures A pointer to the proposal procedure set to write. If NULL,
+ *                                nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_proposal_procedures_if_present(cardano_cbor_writer_t* writer, const cardano_proposal_procedure_set_t* proposal_procedures);
+
+/**
+ * \brief Writes a body treasury value field as a key value pair when the value is present.
+ *
+ * This function writes map key 21 followed by the CBOR encoding of \p treasury_value to the given
+ * writer. If \p treasury_value is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] treasury_value A pointer to the unsigned integer value to write. If NULL, nothing is
+ *                           written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_treasury_value_if_present(cardano_cbor_writer_t* writer, const uint64_t* treasury_value);
+
+/**
+ * \brief Writes a body donation field as a key value pair when the value is present.
+ *
+ * This function writes map key 22 followed by the CBOR encoding of \p donation to the given
+ * writer. If \p donation is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] donation A pointer to the unsigned integer value to write. If NULL, nothing is
+ *                     written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_donation_if_present(cardano_cbor_writer_t* writer, const uint64_t* donation);
+
+/**
+ * \brief Writes a body required top level guards field as a key value pair when the value is present.
+ *
+ * This function writes map key 24 followed by the CBOR encoding of \p required_top_level_guards
+ * to the given writer. If \p required_top_level_guards is NULL, nothing is written and the
+ * function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] required_top_level_guards A pointer to the required guards map to write. If NULL,
+ *                                      nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_required_top_level_guards_if_present(cardano_cbor_writer_t* writer, const cardano_required_guards_map_t* required_top_level_guards);
+
+/**
+ * \brief Writes a body direct deposits field as a key value pair when the value is present.
+ *
+ * This function writes map key 25 followed by the CBOR encoding of \p direct_deposits to the
+ * given writer. If \p direct_deposits is NULL, nothing is written and the function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] direct_deposits A pointer to the direct deposit map to write. If NULL, nothing is
+ *                            written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_direct_deposits_if_present(cardano_cbor_writer_t* writer, const cardano_direct_deposit_map_t* direct_deposits);
+
+/**
+ * \brief Writes a body account balance intervals field as a key value pair when the value is present.
+ *
+ * This function writes map key 26 followed by the CBOR encoding of \p account_balance_intervals
+ * to the given writer. If \p account_balance_intervals is NULL, nothing is written and the
+ * function succeeds.
+ *
+ * \param[in] writer A pointer to the CBOR writer. This parameter must not be NULL.
+ * \param[in] account_balance_intervals A pointer to the account balance intervals map to write.
+ *                                      If NULL, nothing is written.
+ *
+ * \return \ref CARDANO_SUCCESS if the field was written or absent, or an appropriate error code
+ *         indicating the failure reason.
+ */
+cardano_error_t
+cardano_body_write_account_balance_intervals_if_present(cardano_cbor_writer_t* writer, const cardano_account_balance_intervals_map_t* account_balance_intervals);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // BIGLUP_LABS_INCLUDE_CARDANO_BODY_FIELDS_H

--- a/lib/src/transaction_body/sub_transaction_body.c
+++ b/lib/src/transaction_body/sub_transaction_body.c
@@ -28,6 +28,7 @@
 
 #include "../allocators.h"
 #include "../cbor/cbor_validation.h"
+#include "internals/body_fields.h"
 
 #include <assert.h>
 #include <string.h>
@@ -307,11 +308,10 @@ get_field_ptr(cardano_sub_transaction_body_t* body, size_t key)
 }
 
 /**
- * \brief Reads a uint64_t value from the CBOR reader and stores it in the specified field.
+ * \brief Reads the time to live field from the CBOR reader and stores it in the specified field.
  *
- * This function reads a uint64_t value from the provided CBOR reader and stores the result
- * in the specified field pointer. It is used as a handler function for parameters that are
- * represented as uint64_t in the sub transaction body.
+ * This function allocates the storage for the time to live value and delegates the wire decoding
+ * to the shared body field codec.
  *
  * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
  * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
@@ -322,7 +322,7 @@ get_field_ptr(cardano_sub_transaction_body_t* body, size_t key)
  *         - An appropriate error code indicating the failure reason.
  */
 static cardano_error_t
-handle_uint64(cardano_cbor_reader_t* reader, void* field_ptr)
+handle_ttl(cardano_cbor_reader_t* reader, void* field_ptr)
 {
   assert(reader != NULL);
   assert(field_ptr != NULL);
@@ -341,15 +341,125 @@ handle_uint64(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
   }
 
-  return cardano_cbor_reader_read_uint(reader, *field);
+  return cardano_body_read_ttl(reader, *field);
 }
 
 /**
- * \brief Reads a cardano_transaction_input_set_t value from the CBOR reader and stores it in the specified field.
+ * \brief Reads the validity start interval field from the CBOR reader and stores it in the specified field.
  *
- * This function reads a cardano_transaction_input_set_t value from the provided CBOR reader and stores the result
- * in the specified field pointer. It is used as a handler function for parameters that are
- * represented as cardano_transaction_input_set_t in the sub transaction body.
+ * This function allocates the storage for the validity start interval value and delegates the
+ * wire decoding to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_validity_start(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_validity_start(reader, *field);
+}
+
+/**
+ * \brief Reads the treasury value field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the treasury value and delegates the wire decoding to
+ * the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_treasury_value(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_treasury_value(reader, *field);
+}
+
+/**
+ * \brief Reads the donation field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the donation value and delegates the wire decoding to
+ * the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_donation(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_donation(reader, *field);
+}
+
+/**
+ * \brief Reads the inputs field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the
+ * transaction input set to the shared body field codec.
  *
  * \param[in] reader A pointer to the CBOR reader from which to read the cardano_transaction_input_set_t value.
  * \param[out] field_ptr A pointer to the field where the read cardano_transaction_input_set_t value should be stored.
@@ -360,7 +470,7 @@ handle_uint64(cardano_cbor_reader_t* reader, void* field_ptr)
  *         - An appropriate error code indicating the failure reason.
  */
 static cardano_error_t
-handle_transaction_input_set(cardano_cbor_reader_t* reader, void* field_ptr)
+handle_inputs(cardano_cbor_reader_t* reader, void* field_ptr)
 {
   assert(reader != NULL);
   assert(field_ptr != NULL);
@@ -372,7 +482,37 @@ handle_transaction_input_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_transaction_input_set_from_cbor(reader, field);
+  return cardano_body_read_inputs(reader, field);
+}
+
+/**
+ * \brief Reads the reference inputs field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the
+ * transaction input set to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the cardano_transaction_input_set_t value.
+ * \param[out] field_ptr A pointer to the field where the read cardano_transaction_input_set_t value should be stored.
+ *                       The field pointer should be of type cardano_transaction_input_set_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the cardano_transaction_input_set_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_reference_inputs(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  cardano_transaction_input_set_t** field = (cardano_transaction_input_set_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  return cardano_body_read_reference_inputs(reader, field);
 }
 
 /**
@@ -403,7 +543,7 @@ handle_transaction_output_list(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_transaction_output_list_from_cbor(reader, field);
+  return cardano_body_read_outputs(reader, field);
 }
 
 /**
@@ -435,7 +575,7 @@ handle_certificate_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  cardano_error_t result = cardano_certificate_set_from_cbor(reader, field);
+  cardano_error_t result = cardano_body_read_certificates(reader, field);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -481,7 +621,7 @@ handle_withdrawal_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  cardano_error_t result = cardano_withdrawal_map_from_cbor(reader, field);
+  cardano_error_t result = cardano_body_read_withdrawals(reader, field);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -499,11 +639,10 @@ handle_withdrawal_map(cardano_cbor_reader_t* reader, void* field_ptr)
 }
 
 /**
- * \brief Reads a cardano_blake2b_hash_t value from the CBOR reader and stores it in the specified field.
+ * \brief Reads the auxiliary data hash field from the CBOR reader and stores it in the specified field.
  *
- * This function reads a cardano_blake2b_hash_t value from the provided CBOR reader and stores the result
- * in the specified field pointer. It is used as a handler function for parameters that are
- * represented as cardano_blake2b_hash_t in the sub transaction body.
+ * This function checks the field for duplicates and delegates the wire decoding of the blake2b
+ * hash to the shared body field codec.
  *
  * \param[in] reader A pointer to the CBOR reader from which to read the cardano_blake2b_hash_t value.
  * \param[out] field_ptr A pointer to the field where the read cardano_blake2b_hash_t value should be stored.
@@ -514,7 +653,7 @@ handle_withdrawal_map(cardano_cbor_reader_t* reader, void* field_ptr)
  *         - An appropriate error code indicating the failure reason.
  */
 static cardano_error_t
-handle_blake2b_hash(cardano_cbor_reader_t* reader, void* field_ptr)
+handle_aux_data_hash(cardano_cbor_reader_t* reader, void* field_ptr)
 {
   assert(reader != NULL);
   assert(field_ptr != NULL);
@@ -526,7 +665,37 @@ handle_blake2b_hash(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_blake2b_hash_from_cbor(reader, field);
+  return cardano_body_read_aux_data_hash(reader, field);
+}
+
+/**
+ * \brief Reads the script data hash field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the blake2b
+ * hash to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the cardano_blake2b_hash_t value.
+ * \param[out] field_ptr A pointer to the field where the read cardano_blake2b_hash_t value should be stored.
+ *                       The field pointer should be of type cardano_blake2b_hash_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the cardano_blake2b_hash_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_script_data_hash(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  cardano_blake2b_hash_t** field = (cardano_blake2b_hash_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  return cardano_body_read_script_data_hash(reader, field);
 }
 
 /**
@@ -558,7 +727,7 @@ handle_multi_asset(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  cardano_error_t result = cardano_multi_asset_from_cbor(reader, field);
+  cardano_error_t result = cardano_body_read_mint(reader, field);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -603,7 +772,7 @@ handle_guard_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_guard_set_from_cbor(reader, field);
+  return cardano_body_read_guards(reader, field);
 }
 
 /**
@@ -641,7 +810,7 @@ handle_network_id(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
   }
 
-  return cardano_cbor_reader_read_uint(reader, (uint64_t*)((void*)*field));
+  return cardano_body_read_network_id(reader, *field);
 }
 
 /**
@@ -672,7 +841,7 @@ handle_voting_procedures(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_voting_procedures_from_cbor(reader, field);
+  return cardano_body_read_voting_procedures(reader, field);
 }
 
 /**
@@ -703,7 +872,7 @@ handle_proposal_procedure_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_proposal_procedure_set_from_cbor(reader, field);
+  return cardano_body_read_proposal_procedures(reader, field);
 }
 
 /**
@@ -734,7 +903,7 @@ handle_required_guards_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_required_guards_map_from_cbor(reader, field);
+  return cardano_body_read_required_top_level_guards(reader, field);
 }
 
 /**
@@ -765,7 +934,7 @@ handle_direct_deposit_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_direct_deposit_map_from_cbor(reader, field);
+  return cardano_body_read_direct_deposits(reader, field);
 }
 
 /**
@@ -796,7 +965,7 @@ handle_account_balance_intervals_map(cardano_cbor_reader_t* reader, void* field_
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_account_balance_intervals_map_from_cbor(reader, field);
+  return cardano_body_read_account_balance_intervals(reader, field);
 }
 
 /**
@@ -821,594 +990,6 @@ handle_invalid_key(cardano_cbor_reader_t* reader, void* field_ptr)
   CARDANO_UNUSED(field_ptr);
 
   return CARDANO_ERROR_INVALID_CBOR_MAP_KEY;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated unsigned integer value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the unsigned integer value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_uint_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const uint64_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_cbor_writer_write_uint(writer, *value);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated input set value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the input set value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_transaction_input_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_transaction_input_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_transaction_input_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated output list value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the output list value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_transaction_output_list_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_transaction_output_list_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_transaction_output_list_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated certificate set value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the certificate set value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_certificate_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_certificate_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_certificate_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated withdrawal map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the withdrawal map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_withdrawal_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_withdrawal_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_withdrawal_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated blake2b hash value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the blake2b hash value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_blake2b_hash_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_blake2b_hash_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_blake2b_hash_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated multi asset value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the multi asset value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_multi_asset_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_multi_asset_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_multi_asset_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated guard set value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the guard set value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_guard_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_guard_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_guard_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated network id value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the network id value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_network_id_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_network_id_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_cbor_writer_write_uint(writer, *value);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated voting procedures value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the voting procedures value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_voting_procedures_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_voting_procedures_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_voting_procedures_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated proposal procedures value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the proposal procedures value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_proposal_procedure_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_proposal_procedure_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_proposal_procedure_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated required guards map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the required guards map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_required_guards_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_required_guards_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_required_guards_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated direct deposit map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the direct deposit map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_direct_deposit_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_direct_deposit_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_direct_deposit_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated account balance intervals map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the account balance intervals map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_account_balance_intervals_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_account_balance_intervals_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_account_balance_intervals_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
 }
 
 /**
@@ -1457,29 +1038,29 @@ create_sub_transaction_body_new(void)
 
 // cppcheck-suppress misra-c2012-8.9; Reason: Is more readable to define the map here
 static const param_handler_t param_handlers[] = {
-  handle_transaction_input_set,
+  handle_inputs,
   handle_transaction_output_list,
   handle_invalid_key, // top-level-only key (fee)
-  handle_uint64,
+  handle_ttl,
   handle_certificate_set,
   handle_withdrawal_map,
   handle_invalid_key, // unused key
-  handle_blake2b_hash,
-  handle_uint64,
+  handle_aux_data_hash,
+  handle_validity_start,
   handle_multi_asset,
   handle_invalid_key, // unused key
-  handle_blake2b_hash,
+  handle_script_data_hash,
   handle_invalid_key, // unused key
   handle_invalid_key, // top-level-only key (collateral)
   handle_guard_set,
   handle_network_id,
   handle_invalid_key, // top-level-only key (collateral return)
   handle_invalid_key, // top-level-only key (total collateral)
-  handle_transaction_input_set,
+  handle_reference_inputs,
   handle_voting_procedures,
   handle_proposal_procedure_set,
-  handle_uint64,
-  handle_uint64,
+  handle_treasury_value,
+  handle_donation,
   handle_invalid_key, // top-level-only key (sub transactions)
   handle_required_guards_map,
   handle_direct_deposit_map,
@@ -1670,133 +1251,133 @@ cardano_sub_transaction_body_to_cbor(const cardano_sub_transaction_body_t* sub_t
     return result;
   }
 
-  result = write_transaction_input_set_if_present(writer, 0U, sub_transaction_body->inputs);
+  result = cardano_body_write_inputs_if_present(writer, sub_transaction_body->inputs);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_transaction_output_list_if_present(writer, 1U, sub_transaction_body->outputs);
+  result = cardano_body_write_outputs_if_present(writer, sub_transaction_body->outputs);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 3U, sub_transaction_body->invalid_after);
+  result = cardano_body_write_ttl_if_present(writer, sub_transaction_body->invalid_after);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_certificate_set_if_present(writer, 4U, sub_transaction_body->certificates);
+  result = cardano_body_write_certificates_if_present(writer, sub_transaction_body->certificates);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_withdrawal_map_if_present(writer, 5U, sub_transaction_body->withdrawals);
+  result = cardano_body_write_withdrawals_if_present(writer, sub_transaction_body->withdrawals);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_blake2b_hash_if_present(writer, 7U, sub_transaction_body->aux_data_hash);
+  result = cardano_body_write_aux_data_hash_if_present(writer, sub_transaction_body->aux_data_hash);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 8U, sub_transaction_body->invalid_before);
+  result = cardano_body_write_validity_start_if_present(writer, sub_transaction_body->invalid_before);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_multi_asset_if_present(writer, 9U, sub_transaction_body->mint);
+  result = cardano_body_write_mint_if_present(writer, sub_transaction_body->mint);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_blake2b_hash_if_present(writer, 11U, sub_transaction_body->script_data_hash);
+  result = cardano_body_write_script_data_hash_if_present(writer, sub_transaction_body->script_data_hash);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_guard_set_if_present(writer, 14U, sub_transaction_body->guards);
+  result = cardano_body_write_guards_if_present(writer, sub_transaction_body->guards);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_network_id_if_present(writer, 15U, sub_transaction_body->network_id);
+  result = cardano_body_write_network_id_if_present(writer, sub_transaction_body->network_id);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_transaction_input_set_if_present(writer, 18U, sub_transaction_body->reference_inputs);
+  result = cardano_body_write_reference_inputs_if_present(writer, sub_transaction_body->reference_inputs);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_voting_procedures_if_present(writer, 19U, sub_transaction_body->voting_procedures);
+  result = cardano_body_write_voting_procedures_if_present(writer, sub_transaction_body->voting_procedures);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_proposal_procedure_set_if_present(writer, 20U, sub_transaction_body->proposal_procedures);
+  result = cardano_body_write_proposal_procedures_if_present(writer, sub_transaction_body->proposal_procedures);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 21U, sub_transaction_body->treasury_value);
+  result = cardano_body_write_treasury_value_if_present(writer, sub_transaction_body->treasury_value);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 22U, sub_transaction_body->donation);
+  result = cardano_body_write_donation_if_present(writer, sub_transaction_body->donation);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_required_guards_map_if_present(writer, 24U, sub_transaction_body->required_top_level_guards);
+  result = cardano_body_write_required_top_level_guards_if_present(writer, sub_transaction_body->required_top_level_guards);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_direct_deposit_map_if_present(writer, 25U, sub_transaction_body->direct_deposits);
+  result = cardano_body_write_direct_deposits_if_present(writer, sub_transaction_body->direct_deposits);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_account_balance_intervals_map_if_present(writer, 26U, sub_transaction_body->account_balance_intervals);
+  result = cardano_body_write_account_balance_intervals_if_present(writer, sub_transaction_body->account_balance_intervals);
 
   if (result != CARDANO_SUCCESS)
   {

--- a/lib/src/transaction_body/transaction_body.c
+++ b/lib/src/transaction_body/transaction_body.c
@@ -29,6 +29,7 @@
 
 #include "../allocators.h"
 #include "../cbor/cbor_validation.h"
+#include "internals/body_fields.h"
 
 #include <assert.h>
 #include <string.h>
@@ -400,6 +401,154 @@ handle_uint64(cardano_cbor_reader_t* reader, void* field_ptr)
 }
 
 /**
+ * \brief Reads the time to live field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the time to live value and delegates the wire decoding
+ * to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_ttl(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_ttl(reader, *field);
+}
+
+/**
+ * \brief Reads the validity start interval field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the validity start interval value and delegates the
+ * wire decoding to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_validity_start(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_validity_start(reader, *field);
+}
+
+/**
+ * \brief Reads the treasury value field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the treasury value and delegates the wire decoding to
+ * the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_treasury_value(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_treasury_value(reader, *field);
+}
+
+/**
+ * \brief Reads the donation field from the CBOR reader and stores it in the specified field.
+ *
+ * This function allocates the storage for the donation value and delegates the wire decoding to
+ * the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the uint64_t value.
+ * \param[out] field_ptr A pointer to the field where the read uint64_t value should be stored.
+ *                       The field pointer should be of type uint64_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the uint64_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_donation(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  uint64_t** field = (uint64_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  *field = _cardano_malloc(sizeof(uint64_t));
+
+  if (*field == NULL)
+  {
+    return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
+  }
+
+  return cardano_body_read_donation(reader, *field);
+}
+
+/**
  * \brief Reads a cardano_transaction_input_set_t value from the CBOR reader and stores it in the specified field.
  *
  * This function reads a cardano_transaction_input_set_t value from the provided CBOR reader and stores the result
@@ -431,6 +580,66 @@ handle_transaction_input_set(cardano_cbor_reader_t* reader, void* field_ptr)
 }
 
 /**
+ * \brief Reads the inputs field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the
+ * transaction input set to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the cardano_transaction_input_set_t value.
+ * \param[out] field_ptr A pointer to the field where the read cardano_transaction_input_set_t value should be stored.
+ *                       The field pointer should be of type cardano_transaction_input_set_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the cardano_transaction_input_set_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_inputs(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  cardano_transaction_input_set_t** field = (cardano_transaction_input_set_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  return cardano_body_read_inputs(reader, field);
+}
+
+/**
+ * \brief Reads the reference inputs field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the
+ * transaction input set to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the cardano_transaction_input_set_t value.
+ * \param[out] field_ptr A pointer to the field where the read cardano_transaction_input_set_t value should be stored.
+ *                       The field pointer should be of type cardano_transaction_input_set_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the cardano_transaction_input_set_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_reference_inputs(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  cardano_transaction_input_set_t** field = (cardano_transaction_input_set_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  return cardano_body_read_reference_inputs(reader, field);
+}
+
+/**
  * \brief Reads a cardano_transaction_output_list_t value from the CBOR reader and stores it in the specified field.
  *
  * This function reads a cardano_transaction_output_list_t value from the provided CBOR reader and stores the result
@@ -458,7 +667,7 @@ handle_transaction_output_list(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_transaction_output_list_from_cbor(reader, field);
+  return cardano_body_read_outputs(reader, field);
 }
 
 /**
@@ -489,7 +698,7 @@ handle_certificate_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_certificate_set_from_cbor(reader, field);
+  return cardano_body_read_certificates(reader, field);
 }
 
 /**
@@ -520,7 +729,7 @@ handle_withdrawal_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_withdrawal_map_from_cbor(reader, field);
+  return cardano_body_read_withdrawals(reader, field);
 }
 
 /**
@@ -555,11 +764,10 @@ handle_update(cardano_cbor_reader_t* reader, void* field_ptr)
 }
 
 /**
- * \brief Reads a cardano_blake2b_hash_t value from the CBOR reader and stores it in the specified field.
+ * \brief Reads the auxiliary data hash field from the CBOR reader and stores it in the specified field.
  *
- * This function reads a cardano_blake2b_hash_t value from the provided CBOR reader and stores the result
- * in the specified field pointer. It is used as a handler function for parameters that are
- * represented as cardano_blake2b_hash_t in the transaction body body.
+ * This function checks the field for duplicates and delegates the wire decoding of the blake2b
+ * hash to the shared body field codec.
  *
  * \param[in] reader A pointer to the CBOR reader from which to read the cardano_blake2b_hash_t value.
  * \param[out] field_ptr A pointer to the field where the read cardano_blake2b_hash_t value should be stored.
@@ -570,7 +778,7 @@ handle_update(cardano_cbor_reader_t* reader, void* field_ptr)
  *         - An appropriate error code indicating the failure reason.
  */
 static cardano_error_t
-handle_blake2b_hash(cardano_cbor_reader_t* reader, void* field_ptr)
+handle_aux_data_hash(cardano_cbor_reader_t* reader, void* field_ptr)
 {
   assert(reader != NULL);
   assert(field_ptr != NULL);
@@ -582,7 +790,37 @@ handle_blake2b_hash(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_blake2b_hash_from_cbor(reader, field);
+  return cardano_body_read_aux_data_hash(reader, field);
+}
+
+/**
+ * \brief Reads the script data hash field from the CBOR reader and stores it in the specified field.
+ *
+ * This function checks the field for duplicates and delegates the wire decoding of the blake2b
+ * hash to the shared body field codec.
+ *
+ * \param[in] reader A pointer to the CBOR reader from which to read the cardano_blake2b_hash_t value.
+ * \param[out] field_ptr A pointer to the field where the read cardano_blake2b_hash_t value should be stored.
+ *                       The field pointer should be of type cardano_blake2b_hash_t*.
+ *
+ * \return \ref cardano_error_t indicating the outcome of the operation.
+ *         - \ref CARDANO_SUCCESS if the cardano_blake2b_hash_t value was successfully read and stored.
+ *         - An appropriate error code indicating the failure reason.
+ */
+static cardano_error_t
+handle_script_data_hash(cardano_cbor_reader_t* reader, void* field_ptr)
+{
+  assert(reader != NULL);
+  assert(field_ptr != NULL);
+
+  cardano_blake2b_hash_t** field = (cardano_blake2b_hash_t**)field_ptr;
+
+  if (*field != NULL)
+  {
+    return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
+  }
+
+  return cardano_body_read_script_data_hash(reader, field);
 }
 
 /**
@@ -613,7 +851,7 @@ handle_multi_asset(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_multi_asset_from_cbor(reader, field);
+  return cardano_body_read_mint(reader, field);
 }
 
 /**
@@ -813,7 +1051,7 @@ handle_guard_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return read_empty_guard_set(reader, is_tagged, field);
   }
 
-  return cardano_guard_set_from_cbor(reader, field);
+  return cardano_body_read_guards(reader, field);
 }
 
 /**
@@ -875,7 +1113,7 @@ handle_required_guards_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_required_guards_map_from_cbor(reader, field);
+  return cardano_body_read_required_top_level_guards(reader, field);
 }
 
 /**
@@ -906,7 +1144,7 @@ handle_direct_deposit_map(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_direct_deposit_map_from_cbor(reader, field);
+  return cardano_body_read_direct_deposits(reader, field);
 }
 
 /**
@@ -937,7 +1175,7 @@ handle_account_balance_intervals_map(cardano_cbor_reader_t* reader, void* field_
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_account_balance_intervals_map_from_cbor(reader, field);
+  return cardano_body_read_account_balance_intervals(reader, field);
 }
 
 /**
@@ -975,7 +1213,7 @@ handle_network_id(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_MEMORY_ALLOCATION_FAILED;
   }
 
-  return cardano_cbor_reader_read_uint(reader, (uint64_t*)((void*)*field));
+  return cardano_body_read_network_id(reader, *field);
 }
 
 /**
@@ -1037,7 +1275,7 @@ handle_voting_procedures(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_voting_procedures_from_cbor(reader, field);
+  return cardano_body_read_voting_procedures(reader, field);
 }
 
 /**
@@ -1068,7 +1306,7 @@ handle_proposal_procedure_set(cardano_cbor_reader_t* reader, void* field_ptr)
     return CARDANO_ERROR_DUPLICATED_CBOR_MAP_KEY;
   }
 
-  return cardano_proposal_procedure_set_from_cbor(reader, field);
+  return cardano_body_read_proposal_procedures(reader, field);
 }
 
 /**
@@ -1180,132 +1418,6 @@ write_transaction_input_set_if_present(cardano_cbor_writer_t* writer, const uint
 /**
  * \brief Writes a key-value pair to the CBOR writer if the value is present.
  *
- * This function writes a key and its associated output list value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the output list value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_transaction_output_list_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_transaction_output_list_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_transaction_output_list_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated certificate set value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the certificate set value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_certificate_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_certificate_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_certificate_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated withdrawal map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the withdrawal map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_withdrawal_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_withdrawal_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_withdrawal_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
  * This function writes a key and its associated update value to the CBOR writer
  * only if the value is not NULL. If the value is NULL, the function does nothing and
  * returns \ref CARDANO_SUCCESS.
@@ -1335,174 +1447,6 @@ write_update_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const
     }
 
     result = cardano_update_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated blake2b hash value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the blake2b hash value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_blake2b_hash_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_blake2b_hash_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_blake2b_hash_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated multi asset value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the multi asset value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_multi_asset_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_multi_asset_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_multi_asset_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated guard set value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the guard set value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_guard_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_guard_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_guard_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated network id value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the network id value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_network_id_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_network_id_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_cbor_writer_write_uint(writer, *value);
 
     if (result != CARDANO_SUCCESS)
     {
@@ -1558,90 +1502,6 @@ write_transaction_output_if_present(cardano_cbor_writer_t* writer, const uint64_
 /**
  * \brief Writes a key-value pair to the CBOR writer if the value is present.
  *
- * This function writes a key and its associated voting procedures value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the voting procedures value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_voting_procedures_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_voting_procedures_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_voting_procedures_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated proposal procedures value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the proposal procedures value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_proposal_procedure_set_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_proposal_procedure_set_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_proposal_procedure_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
  * This function writes a key and its associated sub transaction set value to the CBOR writer
  * only if the value is not NULL. If the value is NULL, the function does nothing and
  * returns \ref CARDANO_SUCCESS.
@@ -1671,132 +1531,6 @@ write_sub_transaction_set_if_present(cardano_cbor_writer_t* writer, const uint64
     }
 
     result = cardano_sub_transaction_set_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated required guards map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the required guards map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_required_guards_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_required_guards_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_required_guards_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated direct deposit map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the direct deposit map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_direct_deposit_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_direct_deposit_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_direct_deposit_map_to_cbor(value, writer);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-  }
-
-  return CARDANO_SUCCESS;
-}
-
-/**
- * \brief Writes a key-value pair to the CBOR writer if the value is present.
- *
- * This function writes a key and its associated account balance intervals map value to the CBOR writer
- * only if the value is not NULL. If the value is NULL, the function does nothing and
- * returns \ref CARDANO_SUCCESS.
- *
- * \param[in] writer A pointer to the CBOR writer. Must not be NULL.
- * \param[in] key The key to be written to the CBOR map.
- * \param[in] value A pointer to the account balance intervals map value to be written. If NULL, nothing is written.
- *
- * \return \ref cardano_error_t indicating the outcome of the operation.
- *         - \ref CARDANO_SUCCESS if the key-value pair was successfully written or if the value is NULL.
- *         - An appropriate error code indicating the failure reason if writing to the CBOR writer fails.
- *
- * \pre \p writer must not be NULL.
- */
-static cardano_error_t
-write_account_balance_intervals_map_if_present(cardano_cbor_writer_t* writer, const uint64_t key, const cardano_account_balance_intervals_map_t* value)
-{
-  assert(writer != NULL);
-
-  if (value != NULL)
-  {
-    cardano_error_t result = cardano_cbor_writer_write_uint(writer, key);
-
-    if (result != CARDANO_SUCCESS)
-    {
-      return result;
-    }
-
-    result = cardano_account_balance_intervals_map_to_cbor(value, writer);
 
     if (result != CARDANO_SUCCESS)
     {
@@ -1934,29 +1668,29 @@ create_transaction_body_new(void)
 
 // cppcheck-suppress misra-c2012-8.9; Reason: Is more readable to define the map here
 static const param_handler_t param_handlers[] = {
-  handle_transaction_input_set,
+  handle_inputs,
   handle_transaction_output_list,
   handle_uint64,
-  handle_uint64,
+  handle_ttl,
   handle_certificate_set,
   handle_withdrawal_map,
   handle_update,
-  handle_blake2b_hash,
-  handle_uint64,
+  handle_aux_data_hash,
+  handle_validity_start,
   handle_multi_asset,
   handle_invalid_key, // unused key
-  handle_blake2b_hash,
+  handle_script_data_hash,
   handle_invalid_key, // unused key
   handle_transaction_input_set,
   handle_guard_set,
   handle_network_id,
   handle_transaction_output,
   handle_uint64,
-  handle_transaction_input_set,
+  handle_reference_inputs,
   handle_voting_procedures,
   handle_proposal_procedure_set,
-  handle_uint64,
-  handle_uint64,
+  handle_treasury_value,
+  handle_donation,
   handle_sub_transaction_set,
   handle_required_guards_map,
   handle_direct_deposit_map,
@@ -2150,14 +1884,14 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_transaction_input_set_if_present(writer, 0U, transaction_body->inputs);
+  result = cardano_body_write_inputs_if_present(writer, transaction_body->inputs);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_transaction_output_list_if_present(writer, 1U, transaction_body->outputs);
+  result = cardano_body_write_outputs_if_present(writer, transaction_body->outputs);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2171,21 +1905,21 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_uint_if_present(writer, 3U, transaction_body->invalid_after);
+  result = cardano_body_write_ttl_if_present(writer, transaction_body->invalid_after);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_certificate_set_if_present(writer, 4U, transaction_body->certificates);
+  result = cardano_body_write_certificates_if_present(writer, transaction_body->certificates);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_withdrawal_map_if_present(writer, 5U, transaction_body->withdrawals);
+  result = cardano_body_write_withdrawals_if_present(writer, transaction_body->withdrawals);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2199,28 +1933,28 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_blake2b_hash_if_present(writer, 7U, transaction_body->aux_data_hash);
+  result = cardano_body_write_aux_data_hash_if_present(writer, transaction_body->aux_data_hash);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 8U, transaction_body->invalid_before);
+  result = cardano_body_write_validity_start_if_present(writer, transaction_body->invalid_before);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_multi_asset_if_present(writer, 9U, transaction_body->mint);
+  result = cardano_body_write_mint_if_present(writer, transaction_body->mint);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_blake2b_hash_if_present(writer, 11U, transaction_body->script_data_hash);
+  result = cardano_body_write_script_data_hash_if_present(writer, transaction_body->script_data_hash);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2234,14 +1968,14 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_guard_set_if_present(writer, 14U, transaction_body->guards);
+  result = cardano_body_write_guards_if_present(writer, transaction_body->guards);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_network_id_if_present(writer, 15U, transaction_body->network_id);
+  result = cardano_body_write_network_id_if_present(writer, transaction_body->network_id);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2262,35 +1996,35 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_transaction_input_set_if_present(writer, 18U, transaction_body->reference_inputs);
+  result = cardano_body_write_reference_inputs_if_present(writer, transaction_body->reference_inputs);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_voting_procedures_if_present(writer, 19U, transaction_body->voting_procedures);
+  result = cardano_body_write_voting_procedures_if_present(writer, transaction_body->voting_procedures);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_proposal_procedure_set_if_present(writer, 20U, transaction_body->proposal_procedures);
+  result = cardano_body_write_proposal_procedures_if_present(writer, transaction_body->proposal_procedures);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 21U, transaction_body->treasury_value);
+  result = cardano_body_write_treasury_value_if_present(writer, transaction_body->treasury_value);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_uint_if_present(writer, 22U, transaction_body->donation);
+  result = cardano_body_write_donation_if_present(writer, transaction_body->donation);
 
   if (result != CARDANO_SUCCESS)
   {
@@ -2304,21 +2038,21 @@ cardano_transaction_body_to_cbor(const cardano_transaction_body_t* transaction_b
     return result;
   }
 
-  result = write_required_guards_map_if_present(writer, 24U, transaction_body->required_top_level_guards);
+  result = cardano_body_write_required_top_level_guards_if_present(writer, transaction_body->required_top_level_guards);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_direct_deposit_map_if_present(writer, 25U, transaction_body->direct_deposits);
+  result = cardano_body_write_direct_deposits_if_present(writer, transaction_body->direct_deposits);
 
   if (result != CARDANO_SUCCESS)
   {
     return result;
   }
 
-  result = write_account_balance_intervals_map_if_present(writer, 26U, transaction_body->account_balance_intervals);
+  result = cardano_body_write_account_balance_intervals_if_present(writer, transaction_body->account_balance_intervals);
 
   if (result != CARDANO_SUCCESS)
   {


### PR DESCRIPTION
Follow up to #135/#136: the transaction body and the sub transaction body were carrying duplicated wire codecs for the 19 field families they share (the Dijkstra work made it visible, keys 24/25/26 had to be added to both files). That duplication is the dangerous kind, a future change to a shared fields wire handling (I.E the possible `AccountBalanceExact` fourth interval case being discussed upstream) would have to be applied twice with nothing enforcing the pair stays in sync.

This extracts one read and one write function per shared field into `transaction_body/internals/body_fields.{c,h}` (non installed, same internals pattern as the tx builder core) and both bodies now delegate. The split is strict: the shared codec is the pure wire form only, level policy stays per body at the call sites, so the sub body keeps its Dijkstra strictness (empty certs/withdrawals/mint rejected, strict guards decode) and the top body keeps its Conway permissiveness (including the permissive empty legacy required_signers path).

Pure refactor guarantees, verified per slice and with a final sweep:
- Both public headers are byte identical (sha pinned) and the exported symbol surface is unchanged (112 symbols both ways).
- Wire behavior is byte identical: full suite green (10,977 tests, existing tests unmodified), both golden `tx.cbor` round trips pass, chunked valgrind clean.
- cppcheck, clang-tidy and the MISRA gate (0 violations) clean.
- Net: transaction_body.c -266 lines, sub_transaction_body.c -419 lines, codecs live once.

Both slices were reviewed line by line against the deleted code before landing.
